### PR TITLE
✨enable streamsaver

### DIFF
--- a/modules/components/src/DataTable/TableToolbar/saveTSV.js
+++ b/modules/components/src/DataTable/TableToolbar/saveTSV.js
@@ -1,12 +1,11 @@
 import { get, flatten } from 'lodash';
-// streamsaver uses ES6 and fails to minify, removing for now.
-// import { createWriteStream, supported } from 'streamsaver';
+import { createWriteStream, supported } from 'streamsaver';
 import { saveAs } from 'file-saver';
 
 import { getAllValue } from '../utils';
 
-const supported = false;
-const createWriteStream = () => {};
+// const supported = false;
+// const createWriteStream = () => {};
 
 function streamMethods(fileName) {
   const fileStream = createWriteStream(fileName);

--- a/modules/components/src/DataTable/TableToolbar/saveTSV.js
+++ b/modules/components/src/DataTable/TableToolbar/saveTSV.js
@@ -4,9 +4,6 @@ import { saveAs } from 'file-saver';
 
 import { getAllValue } from '../utils';
 
-// const supported = false;
-// const createWriteStream = () => {};
-
 function streamMethods(fileName) {
   const fileStream = createWriteStream(fileName);
   const writer = fileStream.getWriter();


### PR DESCRIPTION
streamsaver includes ES6 

project using arranger will need run it (ang graphql-fields) through babel.

example using create react app would be to use `react-app-rewired` and a config-override.js file containing something like 

```js
const path = require('path');
const fs = require('fs');

const appDirectory = fs.realpathSync(process.cwd());
const resolveApp = relativePath => path.resolve(appDirectory, relativePath);

module.exports = function(config, env) {
  config.module.rules[1].oneOf[1].include = [
    config.module.rules[1].oneOf[1].include,
    resolveApp('node_modules/graphql-fields'),
    resolveApp('node_modules/streamsaver'),
  ];

  return config;
};
```