### PR TITLE
🐛 aggregations middleware bug

### DIFF
--- a/modules/middleware/package.json
+++ b/modules/middleware/package.json
@@ -10,7 +10,8 @@
     "build": "mkdir -p src && babel src --out-dir dist",
     "prepare": "npm run build",
     "watch": "mkdir -p src && babel src --watch --out-dir dist",
-    "flow": "flow"
+    "flow": "flow",
+    "test": "jest"
   },
   "repository": {
     "type": "git",

--- a/modules/middleware/src/aggregations.js
+++ b/modules/middleware/src/aggregations.js
@@ -1,4 +1,5 @@
 import { CONSTANTS } from './constants';
+import { merge } from 'lodash';
 import FilterProcessor from './filters';
 /*
     Aggregation Processor
@@ -174,14 +175,14 @@ export default class AggregationProcessor {
               // There is a query but it is just the nested field - just add it to aggs
               Object.assign(nested_aggs, nested_field_agg);
             }
+          } else {
+            const filteredAgg = this.create_filtered_agg(
+              field,
+              query,
+              nested_field_agg,
+            );
+            Object.assign(nested_aggs, filteredAgg);
           }
-
-          const filteredAgg = this.create_filtered_agg(
-            field,
-            query,
-            nested_field_agg,
-          );
-          Object.assign(nested_aggs, filteredAgg);
         } else {
           // No query - just add to aggs
           Object.assign(nested_aggs, nested_field_agg);
@@ -204,10 +205,10 @@ export default class AggregationProcessor {
         }
 
         if (cleaned_query) {
-          const filteredAgg = this.create_filtered_agg(
+          // needs to be global of ES will auto filter the aggs results
+          const filteredAgg = this.create_global_agg(
             field,
-            cleaned_query,
-            field_agg,
+            this.create_filtered_agg(field, cleaned_query, field_agg),
           );
           Object.assign(aggs, filteredAgg);
         } else {

--- a/modules/middleware/src/aggregations.js
+++ b/modules/middleware/src/aggregations.js
@@ -385,7 +385,7 @@ export default class AggregationProcessor {
       const globalAgg = this.create_global_agg(short_nested_path, nested_aggs);
 
       // This line modifies the input aggs
-      Object.assign(aggs, globalAgg);
+      merge(aggs, globalAgg);
     }
 
     // Return the input aggs, potentially modified
@@ -420,7 +420,7 @@ export default class AggregationProcessor {
       }
 
       if (nested_aggs.hasOwnProperty(p)) {
-        nested_aggs = nested_aggs[path].aggs;
+        nested_aggs = nested_aggs[p].aggs;
         continue;
       }
 

--- a/modules/middleware/test/aggregations.test.js
+++ b/modules/middleware/test/aggregations.test.js
@@ -1,0 +1,135 @@
+import AggregationProcessor from '../src/aggregations.js';
+
+const input = {
+  filters: {},
+  fields: [
+    'access',
+    'cases__samples__portions__is_ffpe',
+    'cases__samples__portions__slides__annotations__notes',
+    'cases__samples__portions__slides__annotations__category',
+  ],
+  nested_fields: [
+    'annotations',
+    'associated_entities',
+    'cases',
+    'cases.annotations',
+    'cases.diagnoses',
+    'cases.diagnoses.treatments',
+    'cases.exposures',
+    'cases.family_histories',
+    'cases.samples',
+    'cases.samples.annotations',
+    'cases.samples.portions',
+    'cases.samples.portions.analytes',
+    'cases.samples.portions.analytes.aliquots',
+    'cases.samples.portions.analytes.aliquots.annotations',
+    'cases.samples.portions.analytes.annotations',
+    'cases.samples.portions.annotations',
+    'cases.samples.portions.slides',
+    'cases.samples.portions.slides.annotations',
+    'downstream_analyses',
+    'downstream_analyses.output_files',
+    'index_files',
+    'metadata_files',
+  ],
+  graphql_fields: {
+    access: { buckets: { key: {} } },
+    cases__samples__portions__is_ffpe: { buckets: { key: {} } },
+    cases__samples__portions__slides__annotations__notes: {
+      buckets: { key: {} },
+    },
+    cases__samples__portions__slides__annotations__category: {
+      buckets: { key: {} },
+    },
+  },
+  global_aggregations: true,
+};
+
+const expectedOutput = {
+  access: {
+    terms: {
+      field: 'access',
+      size: 100,
+    },
+  },
+  'cases:global': {
+    global: {},
+    aggs: {
+      cases: {
+        nested: {
+          path: 'cases',
+        },
+        aggs: {
+          'cases.samples': {
+            nested: {
+              path: 'cases.samples',
+            },
+            aggs: {
+              'cases.samples.portions': {
+                nested: {
+                  path: 'cases.samples.portions',
+                },
+                aggs: {
+                  'cases.samples.portions.is_ffpe': {
+                    aggs: {
+                      rn: {
+                        reverse_nested: {},
+                      },
+                    },
+                    terms: {
+                      field: 'cases.samples.portions.is_ffpe',
+                      size: 100,
+                    },
+                  },
+                  'cases.samples.portions.slides': {
+                    nested: {
+                      path: 'cases.samples.portions.slides',
+                    },
+                    aggs: {
+                      'cases.samples.portions.slides.annotations': {
+                        nested: {
+                          path: 'cases.samples.portions.slides.annotations',
+                        },
+                        aggs: {
+                          'cases.samples.portions.slides.annotations.notes': {
+                            aggs: {
+                              rn: {
+                                reverse_nested: {},
+                              },
+                            },
+                            terms: {
+                              field:
+                                'cases.samples.portions.slides.annotations.notes',
+                              size: 100,
+                            },
+                          },
+                          'cases.samples.portions.slides.annotations.category': {
+                            aggs: {
+                              rn: {
+                                reverse_nested: {},
+                              },
+                            },
+                            terms: {
+                              field:
+                                'cases.samples.portions.slides.annotations.category',
+                              size: 100,
+                            },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+test('build_aggregations should handle nested aggregations', () => {
+  const actualOutput = new AggregationProcessor().build_aggregations(input);
+  expect(actualOutput).toEqual(expectedOutput);
+});


### PR DESCRIPTION
original python code: https://github.com/NCI-GDC/gdcapi/blob/develop/gdcapi/graphql_schemas/utils.py#L898

In `build_aggregations`, the loop over `fields` is overriding the the entire collection of the nested fields on every iteration, resulting in the output `agg` being incorrect. This explains why only the last field of those that share common paths are resolved. This is likely because of the use of `Object.assign` which doesn't do a deep merge. There may be a difference in behaviour between python's library `update` method and the JS `Object.assign`, or there was some error in porting.

<img width="1151" alt="screen shot 2018-02-26 at 5 25 22 pm" src="https://user-images.githubusercontent.com/11821106/36699264-21e92f60-1b1a-11e8-933d-38532fd7153e.png">

Particularly worth noting is that the call to `ensure_path_to_agg` is overriding `agg`. From comparing the code, this seems consistent with the original python code, but could use confirmation.

Some difference in the ported implementation of `build_aggregations` was identified and corrected so far, but yielded no difference to the result so far.

On GDC, the equivalent query returns the following:
```javascript
{
  "data": {
    "repository": {
      "files": {
        "aggregations": {
          "access": {
            "buckets": [
              {
                "key": "controlled"
              },
              {
                "key": "open"
              }
            ]
          },
          "cases__samples__portions__is_ffpe": {
            "buckets": [
              {
                "key": "false"
              },
              {
                "key": "true"
              }
            ]
          },
          "cases__samples__portions__slides__annotations__category": {
            "buckets": [
              {
                "key": "Item is noncanonical"
              },
              {
                "key": "General"
              },
              {
                "key": "Barcode incorrect"
              }
            ]
          },
          "cases__samples__portions__slides__annotations__notes": {
            "buckets": [
              {
                "key": "No Matching Normal"
              },
              {
                "key": "Originally identified as primary solid tumor, reclassified as metastatic.  Data associated with this barcode will be transitioned to the correct barcode.  Original barcode was TCGA-XV-AB01-01A-01-TS1. Correct barcode is TCGA-XV-AB01-06A-01-TS1"
              },
              {
                "key": "Slide barcode TCGA-77-7138-01A-02-BS2 differs from parent portion barcode TCGA-77-7138-01A-41"
              },
              {
                "key": "Slide barcode TCGA-77-7140-01A-02-BS2 differs from parent portion barcode TCGA-77-7140-01A-41"
              },
              {
                "key": "Slide barcode TCGA-CV-7099-01A-02-BS2 differs from parent portion barcode TCGA-CV-7099-01A-41"
              },
              {
                "key": "Slide barcode TCGA-CJ-4897-01A-01-BS1 differs from parent portion barcode TCGA-CJ-4897-01A-03"
              },
              {
                "key": "Slide barcode TCGA-B2-3923-01B-09-BS9 differs from parent portion barcode TCGA-B2-3923-01B-10"
              }
            ]
          }
        }
      }
    }
  }
}
```

