### PR TITLE
🐛 range aggs should not filter themselves (like terms)

### DIFF
--- a/modules/components/src/SQONView/index.js
+++ b/modules/components/src/SQONView/index.js
@@ -124,7 +124,7 @@ const SQON = ({
             {Clear({ nextSQON: null })}
           </Row>
           {sqonContent.map((valueSQON, i) => {
-            const { op, content: { field, fields } } = valueSQON;
+            const { op, content: { field, fields, entity } } = valueSQON;
             const value = [].concat(valueSQON.content.value || []);
             const isSingleValue = !Array.isArray(value) || value.length === 1;
             return (
@@ -134,7 +134,8 @@ const SQON = ({
                 style={{ alignItems: 'center' }}
               >
                 {FieldCrumb({
-                  field: op === 'filter' ? op : field,
+                  field:
+                    op === 'filter' ? (entity ? `${entity}.${op}` : op) : field,
                   nextSQON: toggleSQON(
                     {
                       op: 'and',
@@ -163,8 +164,10 @@ const SQON = ({
                         op === 'filter'
                           ? replaceFilterSQON(
                               {
-                                op: 'and',
-                                content: [],
+                                op: 'filter',
+                                content: {
+                                  ...(entity && { entity }),
+                                },
                               },
                               sqon,
                             )

--- a/modules/components/src/TextFilter/TextFilter.js
+++ b/modules/components/src/TextFilter/TextFilter.js
@@ -4,7 +4,7 @@ import SearchIcon from 'react-icons/lib/fa/search';
 import TextInput from '../Input';
 import { replaceFilterSQON } from '../SQONView/utils';
 
-export const generateNextSQON = value => ({ sqon, fields }) =>
+export const generateNextSQON = value => ({ sqon, fields, entity }) =>
   replaceFilterSQON(
     {
       op: 'and',
@@ -14,6 +14,7 @@ export const generateNextSQON = value => ({ sqon, fields }) =>
           content: {
             fields: fields,
             value,
+            ...(entity && { entity }),
           },
         },
       ],

--- a/modules/middleware/src/aggregations.js
+++ b/modules/middleware/src/aggregations.js
@@ -227,12 +227,12 @@ export default class AggregationProcessor {
     use_if_clean_empty = null,
   }) {
     return this.remove_pred_from_query(
-      item => {
-        return item?.terms?.hasOwnProperty(field);
-      },
       item =>
-        !item.hasOwnProperty('terms') ||
-        (item.hasOwnProperty('terms') && !item.terms.hasOwnProperty(field)),
+        item?.terms?.hasOwnProperty(field) ||
+        item?.range?.hasOwnProperty(field),
+      item =>
+        !item?.terms?.hasOwnProperty(field) &&
+        !item?.range?.hasOwnProperty(field),
       query,
       use_if_not_found,
       use_if_clean_empty,


### PR DESCRIPTION
a little fix to enable range aggs to not filter themselves, similar to term aggs