### PR TITLE
Fixes extra border on last pagination button

### DIFF
--- a/modules/components/public/themeStyles/beagle/beagle.css
+++ b/modules/components/public/themeStyles/beagle/beagle.css
@@ -89,6 +89,9 @@ div {
   background: #f0f1f6;
   color: #009bb8;
 }
+.ReactTable .-pagination_button.-toEnd {
+  border: none;
+}
 .ReactTable a {
   color: #90278e;
 }


### PR DESCRIPTION
Current:
![image](https://user-images.githubusercontent.com/6350043/37215524-2725d356-2386-11e8-8459-1b69511ba206.png)
Without border on `-toEnd`
![image](https://user-images.githubusercontent.com/6350043/37215556-4172c106-2386-11e8-9427-9be8388baf8f.png)
