### PR TITLE
🐛 fix handling of the  field in the extended mapping

### DIFF
--- a/modules/mapping-utils/src/index.js
+++ b/modules/mapping-utils/src/index.js
@@ -8,22 +8,10 @@ export { default as mappingToAggsState } from './mappingToAggsState';
 export { default as esToAggTypeMap } from './esToAggTypeMap';
 export { default as mappingToColumnsState } from './mappingToColumnsState';
 export { default as mappingToNestedTypes } from './mappingToNestedTypes';
-export { default as mappingToScalarFields } from './mappingToScalarFields';
+export { default as mappingToScalarFields, esToGraphqlTypeMap } from './mappingToScalarFields';
 export { default as getNestedFields } from './getNestedFields';
 export { default as flattenMapping } from './flattenMapping';
 export { default as extendFields } from './extendFields';
 export {
   default as mappingToDisplayTreeData,
 } from './mappingToDisplayTreeData';
-
-export let esToGraphqlTypeMap = {
-  keyword: 'String',
-  string: 'String',
-  text: 'String',
-  date: 'String',
-  boolean: 'Boolean',
-  long: 'Float',
-  double: 'Float',
-  integer: 'Float',
-  float: 'Float',
-};

--- a/modules/mapping-utils/src/mappingToFields.js
+++ b/modules/mapping-utils/src/mappingToFields.js
@@ -4,14 +4,16 @@ import mappingToScalarFields from './mappingToScalarFields';
 import createConnectionTypeDefs from './createConnectionTypeDefs';
 import mappingToObjectTypes from './mappingToObjectTypes';
 
-let mappingToFields = ({ type }) => {
+let mappingToFields = ({ type, parent }) => {
   return [
-    mappingToObjectTypes(type.name, type.mapping),
+    mappingToObjectTypes(type.name, type.mapping, parent, type.extendedFields),
     Object.entries(type.mapping)
       .filter(([, metadata]) => metadata.type === 'nested')
       .map(([field, metadata]) =>
         mappingToFields({
+          parent: [parent, field].filter(Boolean).join('.'),
           type: {
+            ...type,
             name: type.name + capitalize(field),
             mapping: metadata.properties,
           },
@@ -20,8 +22,8 @@ let mappingToFields = ({ type }) => {
     createConnectionTypeDefs({
       type,
       fields: [
-        mappingToScalarFields(type.mapping, type.extendedFields),
-        mappingToNestedFields(type.name, type.mapping),
+        mappingToScalarFields(type.mapping, type.extendedFields, parent),
+        mappingToNestedFields(type.name, type.mapping, parent, type.extendedFields),
         type.customFields,
       ],
     }),

--- a/modules/mapping-utils/src/mappingToNestedTypes.js
+++ b/modules/mapping-utils/src/mappingToNestedTypes.js
@@ -1,35 +1,48 @@
-import { capitalize } from 'lodash'
-import mappingToNestedFields from './mappingToNestedFields'
-import mappingToScalarFields from './mappingToScalarFields'
-import createConnectionTypeDefs from './createConnectionTypeDefs'
-import mappingToObjectTypes from './mappingToObjectTypes'
+import { capitalize } from 'lodash';
+import mappingToNestedFields from './mappingToNestedFields';
+import mappingToScalarFields from './mappingToScalarFields';
+import createConnectionTypeDefs from './createConnectionTypeDefs';
+import mappingToObjectTypes from './mappingToObjectTypes';
 
-let mappingToNestedTypes = (type, mapping) => {
+let mappingToNestedTypes = (type, mapping, parent, extendedFields) => {
   return Object.entries(mapping)
     .filter(([, metadata]) => metadata.type === 'nested')
     .map(
       ([field, metadata]) => `
-        ${mappingToObjectTypes(type + capitalize(field), metadata.properties)},
+        ${mappingToObjectTypes(
+          type + capitalize(field),
+          metadata.properties,
+          [parent, field].filter(Boolean).join('.'),
+          extendedFields,
+        )},
          ${mappingToNestedTypes(
            type + capitalize(field),
            metadata.properties,
+           [parent, field].filter(Boolean).join('.'),
+           extendedFields,
          ).join('\n')}
         ${createConnectionTypeDefs({
           type: {
+            ...type,
             name: type + capitalize(field),
             mapping: metadata.properties,
           },
           fields: [
-            mappingToScalarFields(metadata.properties),
+            mappingToScalarFields(
+              metadata.properties,
+              extendedFields,
+              [parent, field].filter(Boolean).join('.'),
+            ),
             mappingToNestedFields(
               type + capitalize(field),
               metadata.properties,
+              [parent, field].filter(Boolean).join('.'),
+              extendedFields,
             ),
           ],
         })}
-
       `,
-    )
-}
+    );
+};
 
-export default mappingToNestedTypes
+export default mappingToNestedTypes;

--- a/modules/mapping-utils/src/mappingToScalarFields.js
+++ b/modules/mapping-utils/src/mappingToScalarFields.js
@@ -10,13 +10,14 @@ export let esToGraphqlTypeMap = {
   float: 'Float',
 };
 
-const maybeArray = (field, extendedFields, type) => {
-  return extendedFields?.find(x => x.field === field)?.isArray
+const maybeArray = (field, extendedFields, type, parent) => {
+  const fullField = [parent, field].filter(Boolean).join('.');
+  return extendedFields?.find(x => x.field === fullField)?.isArray
     ? `[${type}]`
     : type;
 };
 
-export default (mapping, extendedFields) => {
+export default (mapping, extendedFields, parent) => {
   return Object.entries(mapping)
     .filter(([, metadata]) =>
       Object.keys(esToGraphqlTypeMap).includes(metadata.type),
@@ -27,6 +28,7 @@ export default (mapping, extendedFields) => {
           field,
           extendedFields,
           esToGraphqlTypeMap[metadata.type],
+          parent,
         )}`,
     );
 };

--- a/modules/schema/src/Root.js
+++ b/modules/schema/src/Root.js
@@ -56,7 +56,7 @@ export let typeDefs = ({ types, rootTypes, scalarTypes }) => [
   AggregationsTypeDefs,
   SortTypeDefs,
   StateTypeDefs,
-  ...types.map(([key, type]) => mappingToFields({ key, type })),
+  ...types.map(([key, type]) => mappingToFields({ key, type, parent: '' })),
 ];
 
 let resolveObject = () => ({});


### PR DESCRIPTION
Array fields were coming back as `[object Object]` even if they were marked as `isArray`

