### PR TITLE
🐛 a couple fixes from the capsid perspective

### DIFF
--- a/modules/components/src/Aggs/RangeAgg.js
+++ b/modules/components/src/Aggs/RangeAgg.js
@@ -1,6 +1,8 @@
 import React, { Component } from 'react';
 import InputRange from 'react-input-range';
 import convert from 'convert-units';
+import _ from 'lodash';
+
 import { replaceSQON } from '../SQONView/utils';
 
 import 'react-input-range/lib/css/index.css';
@@ -114,7 +116,7 @@ class RangeAgg extends Component {
                 <span className={`arrow ${isCollapsed && 'collapsed'}`} />
               )}
             </div>
-            {[!isCollapsed, min != null, max != null].every(Boolean) && (
+            {[!isCollapsed, !_.isNil(min), !_.isNil(max)].every(Boolean) && (
               <div className="range-wrapper">
                 <div className="unit-wrapper">
                   {unit &&

--- a/modules/components/src/Aggs/RangeAgg.js
+++ b/modules/components/src/Aggs/RangeAgg.js
@@ -114,7 +114,7 @@ class RangeAgg extends Component {
                 <span className={`arrow ${isCollapsed && 'collapsed'}`} />
               )}
             </div>
-            {[!isCollapsed, min, max].every(Boolean) && (
+            {[!isCollapsed, min != null, max != null].every(Boolean) && (
               <div className="range-wrapper">
                 <div className="unit-wrapper">
                   {unit &&

--- a/modules/components/src/Aggs/RangeAgg.js
+++ b/modules/components/src/Aggs/RangeAgg.js
@@ -49,21 +49,21 @@ class RangeAgg extends Component {
     let { handleChange } = this.props;
     let { field, value: { min, max } } = this.state;
     handleChange?.({
-        field,
-        min,
-        max,
-        generateNextSQON: sqon =>
-          replaceSQON(
-            {
-              op: 'and',
-              content: [
-                { op: '>=', content: { field, value: min } },
-                { op: '<=', content: { field, value: max } },
-              ],
-            },
-            sqon,
-          ),
-      });
+      field,
+      min,
+      max,
+      generateNextSQON: sqon =>
+        replaceSQON(
+          {
+            op: 'and',
+            content: [
+              { op: '>=', content: { field, value: min } },
+              { op: '<=', content: { field, value: max } },
+            ],
+          },
+          sqon,
+        ),
+    });
   };
 
   setValue = ({ min, max }) => {
@@ -114,42 +114,40 @@ class RangeAgg extends Component {
                 <span className={`arrow ${isCollapsed && 'collapsed'}`} />
               )}
             </div>
-            {!isCollapsed &&
-              min !== null &&
-              max !== null && (
-                <div className="range-wrapper">
-                  <div className="unit-wrapper">
-                    {unit &&
-                      SUPPORTED_CONVERSIONS[convert().describe(unit).measure]
-                        .map(x => convert().describe(x))
-                        .map(x => ({ ...x, active: x.abbr === displayUnit }))
-                        .map(({ abbr, plural, active }) => (
-                          <span key={abbr}>
-                            <input
-                              type="radio"
-                              id={abbr}
-                              value={abbr}
-                              checked={active}
-                              onChange={e =>
-                                this.setState({ displayUnit: e.target.value })
-                              }
-                            />
-                            <label htmlFor={abbr}>{plural}</label>
-                          </span>
-                        ))}
-                  </div>
-                  <div className="input-range-wrapper">
-                    <InputRange
-                      minValue={min}
-                      maxValue={max}
-                      value={value}
-                      formatLabel={this.formatRangeLabel}
-                      onChange={x => this.setValue(x)}
-                      onChangeComplete={this.onChangeComplete}
-                    />
-                  </div>
+            {[!isCollapsed, min, max].every(Boolean) && (
+              <div className="range-wrapper">
+                <div className="unit-wrapper">
+                  {unit &&
+                    SUPPORTED_CONVERSIONS[convert().describe(unit).measure]
+                      .map(x => convert().describe(x))
+                      .map(x => ({ ...x, active: x.abbr === displayUnit }))
+                      .map(({ abbr, plural, active }) => (
+                        <span key={abbr}>
+                          <input
+                            type="radio"
+                            id={abbr}
+                            value={abbr}
+                            checked={active}
+                            onChange={e =>
+                              this.setState({ displayUnit: e.target.value })
+                            }
+                          />
+                          <label htmlFor={abbr}>{plural}</label>
+                        </span>
+                      ))}
                 </div>
-              )}
+                <div className="input-range-wrapper">
+                  <InputRange
+                    minValue={min}
+                    maxValue={max}
+                    value={value}
+                    formatLabel={this.formatRangeLabel}
+                    onChange={x => this.setValue(x)}
+                    onChangeComplete={this.onChangeComplete}
+                  />
+                </div>
+              </div>
+            )}
           </div>
         )}
       />

--- a/modules/components/src/Arranger/CurrentSQON.js
+++ b/modules/components/src/Arranger/CurrentSQON.js
@@ -20,7 +20,28 @@ const fetchExtendedMapping = ({ graphqlField, projectId }) =>
     extendedMapping: response.data[graphqlField].extended,
   }));
 
-const CurrentSQON = ({ sqon, setSQON, graphqlField, projectId }) => {
+export const CurrentSQON = ({ sqon, setSQON, extendedMapping, ...props }) => (
+  <SQONView
+    sqon={sqon}
+    FieldCrumb={({ field, nextSQON, ...props }) => (
+      <Field {...{ field, ...props }}>
+        {extendedMapping?.find(e => e.field === field)?.displayName || field}
+      </Field>
+    )}
+    ValueCrumb={({ value, nextSQON, ...props }) => (
+      <Value onClick={() => setSQON(nextSQON)} {...props}>
+        {value}
+      </Value>
+    )}
+    Clear={({ nextSQON }) => (
+      <Bubble className="sqon-clear" onClick={() => setSQON(nextSQON)}>
+        Clear
+      </Bubble>
+    )}
+  />
+);
+
+const CurrentSQONState = ({ sqon, setSQON, graphqlField, projectId }) => {
   return (
     <Component
       initialState={{ extendedMapping: null }}
@@ -32,31 +53,11 @@ const CurrentSQON = ({ sqon, setSQON, graphqlField, projectId }) => {
         )
       }
     >
-      {({ state: { extendedMapping } }) => {
-        return (
-          <SQONView
-            sqon={sqon}
-            FieldCrumb={({ field, ...props }) => (
-              <Field {...{ field, ...props }}>
-                {extendedMapping?.find(e => e.field === field)?.displayName ||
-                  field}
-              </Field>
-            )}
-            ValueCrumb={({ value, nextSQON, ...props }) => (
-              <Value onClick={() => setSQON(nextSQON)} {...props}>
-                {value}
-              </Value>
-            )}
-            Clear={({ nextSQON }) => (
-              <Bubble className="sqon-clear" onClick={() => setSQON(nextSQON)}>
-                Clear
-              </Bubble>
-            )}
-          />
-        );
-      }}
+      {({ state: { extendedMapping } }) => (
+        <CurrentSQON {...{ sqon, setSQON, extendedMapping }} />
+      )}
     </Component>
   );
 };
 
-export default CurrentSQON;
+export default CurrentSQONState;


### PR DESCRIPTION
a few things here:
 - a slightly more robust null check for the range agg, so it doesn't try to render the slider if it doesn't have the appropriate data to do so
 - separated the current sqon extended mapping api fetching / state from the current sqon view component
 - removed a react warning due to passing `nextSQON` prop through to a DOM element