### PR TITLE
🐛 term agg - don't fall over if the bucket doesn't have a count

### DIFF
--- a/modules/components/src/Aggs/TermAgg.js
+++ b/modules/components/src/Aggs/TermAgg.js
@@ -138,9 +138,11 @@ class TermAggs extends React.Component {
                           {bucket.name}
                         </OverflowTooltippedLabel> */}
                       </span>
-                      <span className="bucket-count">
-                        {bucket.doc_count.toLocaleString()}
-                      </span>
+                      {bucket.doc_count && (
+                        <span className="bucket-count">
+                          {bucket.doc_count.toLocaleString()}
+                        </span>
+                      )}
                     </Content>
                   ))}
 


### PR DESCRIPTION
Another capsid related item - capsid's agg bucket counts returned by search aren't accurate (due to its data model), and it's not feasible to give accurate counts within the time constraints of running a search. So, we're going to omit the counts and provide a button to fetch them if the user chooses.

Given the situation we need the term agg to render properly even if bucket count isn't present.