### PR TITLE
🐛 normalize / denormalize data in / out of range agg

### DIFF
--- a/modules/components/src/Aggs/RangeAgg.js
+++ b/modules/components/src/Aggs/RangeAgg.js
@@ -27,8 +27,8 @@ class RangeAgg extends Component {
       unit: unit,
       displayUnit: unit,
       value: {
-        min: value ? value.min || min : min,
-        max: value ? value.max || max : max,
+        min: !_.isNil(value) ? value.min || min : min,
+        max: !_.isNil(value) ? value.max || max : max,
       },
     };
   }
@@ -42,8 +42,14 @@ class RangeAgg extends Component {
       min,
       max,
       value: {
-        min: Math.max(externalVal?.min || value.min, min),
-        max: Math.min(externalVal?.max || value.max, max),
+        min: Math.max(
+          !_.isNil(externalVal?.min) ? externalVal.min : value.min,
+          min,
+        ),
+        max: Math.min(
+          !_.isNil(externalVal?.max) ? externalVal.max : value.max,
+          max,
+        ),
       },
     });
   }

--- a/modules/components/src/utils/mapObjectValues.js
+++ b/modules/components/src/utils/mapObjectValues.js
@@ -1,6 +1,0 @@
-import _ from 'lodash';
-
-const mapObjectValues = (obj, fn) =>
-  _.mapValues(obj, x => (_.isObject(x) ? mapObjectValues(x, fn) : fn(x)));
-
-export default mapObjectValues;

--- a/modules/components/src/utils/mapObjectValues.js
+++ b/modules/components/src/utils/mapObjectValues.js
@@ -1,0 +1,6 @@
+import _ from 'lodash';
+
+const mapObjectValues = (obj, fn) =>
+  _.mapValues(obj, x => (_.isObject(x) ? mapObjectValues(x, fn) : fn(x)));
+
+export default mapObjectValues;


### PR DESCRIPTION
Apparently the input range slider component we're using only handles integers, not doubles. In an effort to not swap out / rebuild the component altogether I'd like to suggest we add the ability to normalize / denormalize the numbers we give to & get from the range agg. Ex. normalize percentages to be between 0 & 100, rather than 0 & 1 (`normalize={x => x * 100}`, `denormalize={x => x / 100}`)

Also I've enabled the 'draggableTrack' prop, which lets you drag the previously selected range around. Ex. select 5->10, drag range to 4->9, 3->8, etc...   