### PR TITLE
✨ term agg now has an include / exclude button option

### DIFF
--- a/modules/components/public/themeStyles/beagle/beagle.css
+++ b/modules/components/public/themeStyles/beagle/beagle.css
@@ -140,6 +140,9 @@ div {
 .aggregation-card .title-wrapper {
   padding-bottom: 7px;
   color: #404c9a;
+}
+.aggregation-card .title-wrapper,
+.aggregation-card .additional-options {
   border-bottom: solid 1px #e0e1e6;
 }
 .aggregation-card .title-wrapper.collapsed {
@@ -151,6 +154,17 @@ div {
   font-weight: bolder;
   font-size: 0.9rem;
   font-family: 'Open Sans', sans-serif;
+}
+.aggregation-card .additional-options {
+  padding: 7px 0;
+  display: flex;
+  justify-content: center;
+}
+.aggregation-card input[type='checkbox'] {
+  pointer-events: none;
+  margin-right: 5px;
+  flex-shrink: 0;
+  vertical-align: middle;
 }
 .aggregation-card .bucket {
   padding-top: 5px;
@@ -195,7 +209,8 @@ div {
 }
 
 .aggregation-card .bucket-item,
-.aggregation-card .input-range__label {
+.aggregation-card .input-range__label,
+.aggregation-card .additional-options {
   font-size: 0.8rem;
 }
 
@@ -435,11 +450,11 @@ div {
   padding-right: 10px;
 }
 
-.tableToolbar .group>:first-child {
+.tableToolbar .group > :first-child {
   border-top-left-radius: 10px;
   border-bottom-left-radius: 10px;
 }
-.tableToolbar .group>:last-child {
+.tableToolbar .group > :last-child {
   border-top-right-radius: 10px;
   border-bottom-right-radius: 10px;
 }

--- a/modules/components/public/themeStyles/beagle/beagle.css
+++ b/modules/components/public/themeStyles/beagle/beagle.css
@@ -142,7 +142,7 @@ div {
   color: #404c9a;
 }
 .aggregation-card .title-wrapper,
-.aggregation-card .additional-options {
+.aggregation-card .filter {
   border-bottom: solid 1px #e0e1e6;
 }
 .aggregation-card .title-wrapper.collapsed {
@@ -155,7 +155,7 @@ div {
   font-size: 0.9rem;
   font-family: 'Open Sans', sans-serif;
 }
-.aggregation-card .additional-options {
+.aggregation-card .filter {
   padding: 7px 0;
   display: flex;
   justify-content: center;
@@ -210,7 +210,7 @@ div {
 
 .aggregation-card .bucket-item,
 .aggregation-card .input-range__label,
-.aggregation-card .additional-options {
+.aggregation-card .filter {
   font-size: 0.8rem;
 }
 

--- a/modules/components/src/Aggs/AggregationCard.css
+++ b/modules/components/src/Aggs/AggregationCard.css
@@ -5,7 +5,7 @@
   align-items: center;
   cursor: pointer;
 }
-.aggregation-card .additional-options {
+.aggregation-card .filter {
   display: flex;
   flex-direction: row;
 }

--- a/modules/components/src/Aggs/AggregationCard.css
+++ b/modules/components/src/Aggs/AggregationCard.css
@@ -5,6 +5,10 @@
   align-items: center;
   cursor: pointer;
 }
+.aggregation-card .additional-options {
+  display: flex;
+  flex-direction: row;
+}
 .aggregation-card .arrow:after {
   content: '›';
 }

--- a/modules/components/src/Aggs/AggsWrapper.js
+++ b/modules/components/src/Aggs/AggsWrapper.js
@@ -2,12 +2,7 @@ import React from 'react';
 import Component from 'react-component-component';
 import './AggregationCard.css';
 
-export default ({
-  children,
-  collapsible = true,
-  displayName,
-  additionalOptions,
-}) => (
+export default ({ children, collapsible = true, displayName, filters }) => (
   <Component initialState={{ isCollapsed: false }}>
     {({ setState, state: { isCollapsed } }) => (
       <div className="aggregation-card">
@@ -24,9 +19,12 @@ export default ({
             <span className={`arrow ${isCollapsed ? 'collapsed' : ''}`} />
           )}
         </div>
-        {additionalOptions && (
-          <div className="additional-options">{additionalOptions}</div>
-        )}
+        {filters &&
+          filters.map((x, i) => (
+            <div key={i} className="filter">
+              {x}
+            </div>
+          ))}
         {!isCollapsed && (
           <div className={`bucket ${isCollapsed ? 'collapsed' : ''}`}>
             {children}

--- a/modules/components/src/Aggs/AggsWrapper.js
+++ b/modules/components/src/Aggs/AggsWrapper.js
@@ -2,7 +2,12 @@ import React from 'react';
 import Component from 'react-component-component';
 import './AggregationCard.css';
 
-export default ({ children, collapsible = true, displayName }) => (
+export default ({
+  children,
+  collapsible = true,
+  displayName,
+  additionalOptions,
+}) => (
   <Component initialState={{ isCollapsed: false }}>
     {({ setState, state: { isCollapsed } }) => (
       <div className="aggregation-card">
@@ -19,6 +24,9 @@ export default ({ children, collapsible = true, displayName }) => (
             <span className={`arrow ${isCollapsed ? 'collapsed' : ''}`} />
           )}
         </div>
+        {additionalOptions && (
+          <div className="additional-options">{additionalOptions}</div>
+        )}
         {!isCollapsed && (
           <div className={`bucket ${isCollapsed ? 'collapsed' : ''}`}>
             {children}

--- a/modules/components/src/Aggs/TermAgg.js
+++ b/modules/components/src/Aggs/TermAgg.js
@@ -90,20 +90,22 @@ class TermAggs extends React.Component {
     return (
       <AggsWrapper
         {...{ displayName, collapsible }}
-        additionalOptions={
-          showExcludeOption && (
-            <IncludeExcludeButton
-              {...{
-                dotField,
-                isActive,
-                isExclude,
-                handleIncludeExcludeChange,
-                buckets: decoratedBuckets,
-                updateIsExclude: x => this.setState({ isExclude: x }),
-              }}
-            />
-          )
-        }
+        filters={[
+          ...(showExcludeOption
+            ? [
+                <IncludeExcludeButton
+                  {...{
+                    dotField,
+                    isActive,
+                    isExclude,
+                    handleIncludeExcludeChange,
+                    buckets: decoratedBuckets,
+                    updateIsExclude: x => this.setState({ isExclude: x }),
+                  }}
+                />,
+              ]
+            : []),
+        ]}
       >
         <div className={`bucket`}>
           {orderBy(decoratedBuckets, 'doc_count', 'desc')

--- a/modules/components/src/Aggs/TermAgg.js
+++ b/modules/components/src/Aggs/TermAgg.js
@@ -1,37 +1,113 @@
 import React from 'react';
-import { orderBy } from 'lodash';
+import { orderBy, truncate } from 'lodash';
+
 import './AggregationCard.css';
-import { toggleSQON } from '../SQONView/utils';
-import { truncate } from 'lodash';
+
+import { removeSQON, toggleSQON } from '../SQONView/utils';
 import AggsWrapper from './AggsWrapper';
+import ToggleButton from '../ToggleButton';
+
+const generateNextSQON = ({ dotField, bucket, isExclude, sqon }) =>
+  toggleSQON(
+    {
+      op: 'and',
+      content: [
+        {
+          op: isExclude ? 'not-in' : 'in',
+          content: {
+            field: dotField,
+            value: [].concat(bucket.name || []),
+          },
+        },
+      ],
+    },
+    sqon,
+  );
+
+const IncludeExcludeButton = ({
+  dotField,
+  buckets,
+  isActive,
+  isExclude,
+  updateIsExclude,
+  handleIncludeExcludeChange,
+}) => (
+  <ToggleButton
+    value={isExclude ? 'exclude' : 'include'}
+    options={[
+      { title: 'Include', value: 'include' },
+      { title: 'Exclude', value: 'exclude' },
+    ]}
+    onChange={({ value, isExclude = value === 'exclude' }) => {
+      const activeBuckets = buckets.filter(b =>
+        isActive({ field: dotField, value: b.name }),
+      );
+      handleIncludeExcludeChange({
+        isExclude,
+        buckets: activeBuckets,
+        generateNextSQON: sqon =>
+          activeBuckets.reduce(
+            (q, bucket) =>
+              generateNextSQON({ dotField, isExclude, bucket, sqon: q }),
+            removeSQON(dotField, sqon),
+          ),
+      });
+      updateIsExclude(isExclude);
+    }}
+  />
+);
 
 class TermAggs extends React.Component {
   // needs ref
 
-  state = { showingMore: false };
+  state = { showingMore: false, isExclude: false };
 
   render() {
     const {
       field = '',
       displayName = 'Unnamed Field',
       buckets = [],
+      decoratedBuckets = buckets.map(b => ({
+        ...b,
+        name: b.key_as_string || b.key,
+      })),
       handleValueClick = () => {},
       isActive = () => {},
       Content = 'div',
       maxTerms = 5,
       collapsible = true,
+      isExclude: externalIsExclude = () => {},
+      showExcludeOption = false,
+      handleIncludeExcludeChange = () => {},
       constructEntryId = ({ value }) => value,
       valueCharacterLimit,
       observableValueInFocus = null,
     } = this.props;
     const { showingMore } = this.state;
     const dotField = field.replace(/__/g, '.');
+    const isExclude =
+      externalIsExclude({ field: dotField }) || this.state.isExclude;
     return (
-      <AggsWrapper {...{ displayName }}>
+      <AggsWrapper
+        {...{ displayName, collapsible }}
+        additionalOptions={
+          showExcludeOption && (
+            <IncludeExcludeButton
+              {...{
+                dotField,
+                isActive,
+                isExclude,
+                handleIncludeExcludeChange,
+                buckets: decoratedBuckets,
+                updateIsExclude: x => this.setState({ isExclude: x }),
+              }}
+            />
+          )
+        }
+      >
         <div className={`bucket`}>
-          {orderBy(buckets, 'doc_count', 'desc')
+          {orderBy(decoratedBuckets, 'doc_count', 'desc')
             .slice(0, showingMore ? Infinity : maxTerms)
-            .map(b => ({ ...b, name: b.key_as_string || b.key }))
             .map(bucket => (
               <Content
                 ref={el =>
@@ -53,22 +129,9 @@ class TermAggs extends React.Component {
                 onClick={() =>
                   handleValueClick({
                     bucket,
+                    isExclude,
                     generateNextSQON: sqon =>
-                      toggleSQON(
-                        {
-                          op: 'and',
-                          content: [
-                            {
-                              op: 'in',
-                              content: {
-                                field: dotField,
-                                value: [].concat(bucket.name || []),
-                              },
-                            },
-                          ],
-                        },
-                        sqon,
-                      ),
+                      generateNextSQON({ isExclude, dotField, bucket, sqon }),
                   })
                 }
               >
@@ -76,12 +139,6 @@ class TermAggs extends React.Component {
                   <input
                     readOnly
                     type="checkbox"
-                    style={{
-                      pointerEvents: 'none',
-                      marginRight: '5px',
-                      flexShrink: 0,
-                      verticalAlign: 'middle',
-                    }}
                     checked={isActive({
                       field: dotField,
                       value: bucket.name,

--- a/modules/components/src/ToggleButton/ToggleButton.css
+++ b/modules/components/src/ToggleButton/ToggleButton.css
@@ -1,0 +1,28 @@
+.toggle-button {
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  height: 30px;
+  font-size: 0.9em;
+}
+.toggle-button .toggle-button-option {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+  border: solid 1px #cacbcf;
+  cursor: pointer;
+  padding: 5px;
+}
+.toggle-button-option:first-child {
+  border-top-left-radius: 100px;
+  border-bottom-left-radius: 100px;
+}
+.toggle-button-option:last-child {
+  border-top-right-radius: 100px;
+  border-bottom-right-radius: 100px;
+}
+.toggle-button-option.active {
+  background: #e5f7fd;
+  border-color: '#00afed';
+}

--- a/modules/components/src/ToggleButton/ToggleButton.js
+++ b/modules/components/src/ToggleButton/ToggleButton.js
@@ -1,21 +1,15 @@
 import React from 'react';
 import './ToggleButton.css';
 
-export default ({
-  value: controlledValue,
-  options = [],
-  onChange = () => {},
-}) => (
+export default ({ value, options = [], onChange = () => {} }) => (
   <div className="toggle-button">
-    {options.map(({ title, value }) => (
+    {options.map(x => (
       <div
-        key={value}
-        className={`toggle-button-option ${
-          controlledValue === value ? 'active' : ''
-        }`}
-        onClick={() => onChange({ value })}
+        key={x.value}
+        className={`toggle-button-option ${value === x.value ? 'active' : ''}`}
+        onClick={() => onChange({ value: x.value })}
       >
-        {title}
+        {x.title}
       </div>
     ))}
   </div>

--- a/modules/components/src/ToggleButton/ToggleButton.js
+++ b/modules/components/src/ToggleButton/ToggleButton.js
@@ -1,0 +1,22 @@
+import React from 'react';
+import './ToggleButton.css';
+
+export default ({
+  value: controlledValue,
+  options = [],
+  onChange = () => {},
+}) => (
+  <div className="toggle-button">
+    {options.map(({ title, value }) => (
+      <div
+        key={value}
+        className={`toggle-button-option ${
+          controlledValue === value ? 'active' : ''
+        }`}
+        onClick={() => onChange({ value })}
+      >
+        {title}
+      </div>
+    ))}
+  </div>
+);

--- a/modules/components/src/ToggleButton/index.js
+++ b/modules/components/src/ToggleButton/index.js
@@ -1,0 +1,1 @@
+export { default } from './ToggleButton';


### PR DESCRIPTION
Capsid needed the option to have a term aggregation that generates a 'not-in' term query, rather than an 'in' one. As a result I've added an include / exclude button to the TermAgg, split in the following ways:
 - A 'ToggleButton' component
 - The AggWrapper now accepts 'filters', to sit above the content of the agg
 - TermAgg now accepts 'isExclude', 'showExcludeOption', and 'handleIncludeExcludeChange' as props