### PR TITLE
✨ give the client the ability to include / exclude missing term

### DIFF
--- a/modules/mapping-utils/src/createConnectionTypeDefs.js
+++ b/modules/mapping-utils/src/createConnectionTypeDefs.js
@@ -33,6 +33,7 @@ export default ({ type, fields = '', createStateTypeDefs = true }) => `
     aggregations(
       filters: JSON
 
+      include_missing: Boolean
       # Should term aggregations be affected by queries that contain filters on their field. For example if a query is filtering primary_site by Blood should the term aggregation on primary_site return all values or just Blood. Set to False for UIs that allow users to select multiple values of an aggregation.
       aggregations_filter_themselves: Boolean
     ): ${type.name}Aggregations

--- a/modules/mapping-utils/src/resolveAggregations.js
+++ b/modules/mapping-utils/src/resolveAggregations.js
@@ -9,7 +9,12 @@ let toGraphqlField = (acc, [a, b]) => ({ ...acc, [a.replace(/\./g, '__')]: b });
 
 export default type => async (
   obj,
-  { offset = 0, filters, aggregations_filter_themselves },
+  {
+    offset = 0,
+    filters,
+    aggregations_filter_themselves,
+    include_missing = true,
+  },
   { es },
   info,
 ) => {
@@ -30,8 +35,10 @@ export default type => async (
     _source: false,
     body,
   });
-
-  const aggregations = flattenAggregations(response.aggregations);
+  const aggregations = flattenAggregations({
+    aggregations: response.aggregations,
+    includeMissing: include_missing,
+  });
 
   return Object.entries(aggregations).reduce(toGraphqlField, {});
 };

--- a/modules/middleware/src/flattenAggregations.js
+++ b/modules/middleware/src/flattenAggregations.js
@@ -1,7 +1,7 @@
 import { get } from 'lodash';
 import { HISTOGRAM, STATS } from './constants';
 
-function flattenAggregations(aggregations) {
+function flattenAggregations({ aggregations, includeMissing = true }) {
   return Object.entries(aggregations).reduce((prunedAggs, [key, value]) => {
     const [field, aggregationType = null] = key.split(':');
 
@@ -16,7 +16,7 @@ function flattenAggregations(aggregations) {
       const missing = get(aggregations, [`${field}:missing`]);
       const buckets = [
         ...value.buckets,
-        ...(missing ? [{ ...missing, key: '_missing' }] : []),
+        ...(includeMissing && missing ? [{ ...missing, key: '_missing' }] : []),
       ];
       return {
         ...prunedAggs,
@@ -30,7 +30,10 @@ function flattenAggregations(aggregations) {
         },
       };
     } else {
-      return { ...prunedAggs, ...flattenAggregations(value) };
+      return {
+        ...prunedAggs,
+        ...flattenAggregations({ aggregations: value, includeMissing }),
+      };
     }
   }, {});
 }

--- a/modules/middleware/test/flattenAggregations.test.js
+++ b/modules/middleware/test/flattenAggregations.test.js
@@ -271,7 +271,7 @@ test('flattenAggregations', () => {
     },
   ];
   tests.forEach(({ input, output }) => {
-    const actualOutput = flattenAggregations(input);
+    const actualOutput = flattenAggregations({ aggregations: input });
     expect(actualOutput).toEqual(output);
   });
 });


### PR DESCRIPTION
some app logic relies on the number of buckets, so giving the client the ability to specify whether or not to include the missing term in aggregations is helpful