### PR TITLE
:bug: default to createState true in mappingToNestedTypes

### DIFF
--- a/modules/mapping-utils/src/mappingToNestedTypes.js
+++ b/modules/mapping-utils/src/mappingToNestedTypes.js
@@ -40,7 +40,6 @@ let mappingToNestedTypes = (type, mapping, parent, extendedFields) => {
               extendedFields,
             ),
           ],
-          createStateTypeDefs: 'createState' in type ? type.createState : true,
         })}
       `,
     );


### PR DESCRIPTION
everywhere else `type` is an obj, but in `mappingToNestedTypes` it's a string. Sets will never have nested fields, and everywhere else the states are wanted, so I guess let `createState` default to true in `mappingToNestedTypes`