### PR TITLE
:bug: fix sets mapping export

### DIFF
--- a/modules/schema/src/index.js
+++ b/modules/schema/src/index.js
@@ -15,7 +15,7 @@ export const setsMapping = {
   createdAt: { type: 'date' },
 };
 
-module.exports = ({
+export default ({
   types = [],
   rootTypes = [],
   scalarTypes = [],


### PR DESCRIPTION
change to using export default, used named export for sets mapping and silently didn't work with `module.exports`, making the terms filter for sets not work.