### PR TITLE
saveSet: allow specify sort and default id field to _id

### DIFF
--- a/modules/components/src/DataTable/ColumnsState.js
+++ b/modules/components/src/DataTable/ColumnsState.js
@@ -7,7 +7,7 @@ let columnFields = `
   state {
     type
     keyField
-    defaultSorted{
+    defaultSorted {
       id
       desc
     }

--- a/modules/components/src/DataTable/DataTable.js
+++ b/modules/components/src/DataTable/DataTable.js
@@ -13,9 +13,16 @@ class DataTable extends React.Component {
       sort: props.config.defaultSorted || [],
     };
   }
+
   componentWillReceiveProps(nextProps) {
     if (!isEqual(nextProps.sqon, this.props.sqon)) {
       this.setState({ page: 0 });
+    }
+    // call onSortedChange here because in componentDidMount config.defaultSorted is null
+    if (
+      !isEqual(nextProps.config.defaultSorted, this.props.config.defaultSorted)
+    ) {
+      this.props.onSortedChange(nextProps.config.defaultSorted);
     }
   }
   render() {
@@ -39,6 +46,7 @@ class DataTable extends React.Component {
       maxPagesOptions,
       projectId = PROJECT_ID,
       downloadUrl = urlJoin(ARRANGER_API, projectId, 'download'),
+      onSortedChange = () => {},
     } = this.props;
     const { page, pageSize, total } = this.state;
 
@@ -71,7 +79,10 @@ class DataTable extends React.Component {
           fetchData={fetchData}
           setSelectedTableRows={setSelectedTableRows}
           onPaginationChange={state => this.setState(state)}
-          onSortedChange={sort => this.setState({ sort, page: 0 })}
+          onSortedChange={sort => {
+            this.setState({ sort, page: 0 });
+            onSortedChange(sort);
+          }}
           defaultPageSize={pageSize}
           loading={loading}
           maxPagesOptions={maxPagesOptions}

--- a/modules/components/src/DataTable/DataTable.js
+++ b/modules/components/src/DataTable/DataTable.js
@@ -47,6 +47,7 @@ class DataTable extends React.Component {
       projectId = PROJECT_ID,
       downloadUrl = urlJoin(ARRANGER_API, projectId, 'download'),
       onSortedChange = () => {},
+      alwaysSorted = [],
     } = this.props;
     const { page, pageSize, total } = this.state;
 
@@ -86,6 +87,7 @@ class DataTable extends React.Component {
           defaultPageSize={pageSize}
           loading={loading}
           maxPagesOptions={maxPagesOptions}
+          alwaysSorted={alwaysSorted}
         />
       </>
     );

--- a/modules/components/src/DataTable/Table/Table.js
+++ b/modules/components/src/DataTable/Table/Table.js
@@ -60,15 +60,13 @@ class DataTable extends React.Component {
       config,
       sqon,
       queryName: 'Table',
-      sort: state.sorted.length
-        ? [
-            ...state.sorted.map(sort => ({
-              field: sort.id,
-              order: sort.desc ? 'desc' : 'asc',
-            })),
-            ...alwaysSorted,
-          ]
-        : alwaysSorted,
+      sort: [
+        ...state.sorted.map(sort => ({
+          field: sort.id,
+          order: sort.desc ? 'desc' : 'asc',
+        })),
+        ...alwaysSorted,
+      ],
       offset: state.page * state.pageSize,
       first: state.pageSize,
     })

--- a/modules/components/src/DataTable/Table/Table.js
+++ b/modules/components/src/DataTable/Table/Table.js
@@ -56,7 +56,6 @@ class DataTable extends React.Component {
 
     this.setState({ loading: true, lastState: state });
 
-    console.log(alwaysSorted);
     fetchData?.({
       config,
       sqon,

--- a/modules/components/src/DataTable/Table/Table.js
+++ b/modules/components/src/DataTable/Table/Table.js
@@ -51,21 +51,25 @@ class DataTable extends React.Component {
 
   // QUESTION: onFetchData? isn't this doing the actual fetching
   onFetchData = state => {
-    const { fetchData, config, sqon } = this.props;
+    const { fetchData, config, sqon, alwaysSorted = [] } = this.props;
     const { selectedTableRows } = this.state;
 
     this.setState({ loading: true, lastState: state });
 
+    console.log(alwaysSorted);
     fetchData?.({
       config,
       sqon,
       queryName: 'Table',
       sort: state.sorted.length
-        ? state.sorted.map(sort => ({
-            field: sort.id,
-            order: sort.desc ? 'desc' : 'asc',
-          }))
-        : null,
+        ? [
+            ...state.sorted.map(sort => ({
+              field: sort.id,
+              order: sort.desc ? 'desc' : 'asc',
+            })),
+            ...alwaysSorted,
+          ]
+        : alwaysSorted,
       offset: state.page * state.pageSize,
       first: state.pageSize,
     })

--- a/modules/components/src/utils/saveSet.js
+++ b/modules/components/src/utils/saveSet.js
@@ -3,7 +3,7 @@ import { graphql } from './api';
 export default ({ type, path, userId, sqon = {}, returnIds = false, api }) =>
   (api || graphql)({
     query: `
-      mutation saveSet($type: String! $userId: String! $sqon: JSON! $path: String!) {
+      mutation saveSet($type: String! $userId: String $sqon: JSON! $path: String!) {
         saveSet(type: $type, userId: $userId, sqon: $sqon, path: $path) {
           setId
           createdAt

--- a/modules/components/src/utils/saveSet.js
+++ b/modules/components/src/utils/saveSet.js
@@ -1,10 +1,18 @@
 import { graphql } from './api';
 
-export default ({ type, path, userId, sqon = {}, returnIds = false, api }) =>
+export default ({
+  type,
+  path,
+  userId,
+  sqon = {},
+  returnIds = false,
+  api,
+  sort = [],
+}) =>
   (api || graphql)({
     query: `
-      mutation saveSet($type: String! $userId: String $sqon: JSON! $path: String!) {
-        saveSet(type: $type, userId: $userId, sqon: $sqon, path: $path) {
+      mutation saveSet($type: String! $userId: String $sqon: JSON! $path: String!, $sort: [Sort]) {
+        saveSet(type: $type, userId: $userId, sqon: $sqon, path: $path, sort: $sort) {
           setId
           createdAt
           path
@@ -16,5 +24,5 @@ export default ({ type, path, userId, sqon = {}, returnIds = false, api }) =>
         }
       }
     `,
-    variables: { sqon, type, userId, path },
+    variables: { sqon, type, userId, path, sort },
   });

--- a/modules/mapping-utils/src/resolveHits.js
+++ b/modules/mapping-utils/src/resolveHits.js
@@ -77,6 +77,7 @@ export default type => async (
     body.search_after = searchAfter;
   }
 
+  console.log(body);
   let { hits } = await es.search({
     index: type.index,
     type: type.es_type,

--- a/modules/mapping-utils/src/resolveHits.js
+++ b/modules/mapping-utils/src/resolveHits.js
@@ -77,7 +77,6 @@ export default type => async (
     body.search_after = searchAfter;
   }
 
-  console.log(body);
   let { hits } = await es.search({
     index: type.index,
     type: type.es_type,

--- a/modules/mapping-utils/src/resolveSets.js
+++ b/modules/mapping-utils/src/resolveSets.js
@@ -16,13 +16,13 @@ const retrieveSetIds = async ({
       ...(!isEmpty(query) && { query }),
       ...(searchAfter && { search_after: searchAfter }),
     };
-    console.log(body);
+
     const response = await es.search({
       index,
       type,
-      // https://github.com/elastic/elasticsearch-js/issues/148#issuecomment-323848693
-      // strings not obj for sort eg ['name:desc']
-      sort: sort.map(({ field, order }) => `${field}:${order}`),
+      sort: sort.map(
+        ({ field, order }) => `${field}${order ? `:${order}` : ''}`,
+      ),
       size: BULK_SIZE,
       body,
     });
@@ -66,7 +66,7 @@ export const saveSet = ({ types }) => async (
     type: es_type,
     query,
     path,
-    sort,
+    sort: sort && sort.length ? sort : [{ field: '_id', order: 'asc' }],
   });
 
   const body = {

--- a/modules/schema/src/Root.js
+++ b/modules/schema/src/Root.js
@@ -48,7 +48,7 @@ let RootTypeDefs = ({ types, rootTypes, scalarTypes }) => `
     saveAggsState(graphqlField: String! state: JSON!): AggsState
     saveColumnsState(graphqlField: String! state: JSON!): ColumnsState
     saveMatchBoxState(graphqlField: String! state: JSON!): MatchBoxState
-    saveSet(type: String! userId: String sqon: JSON! path: String!): Set
+    saveSet(type: String! userId: String sqon: JSON! path: String! sort: [String]): Set
   }
 
   schema {

--- a/modules/schema/src/Root.js
+++ b/modules/schema/src/Root.js
@@ -48,7 +48,7 @@ let RootTypeDefs = ({ types, rootTypes, scalarTypes }) => `
     saveAggsState(graphqlField: String! state: JSON!): AggsState
     saveColumnsState(graphqlField: String! state: JSON!): ColumnsState
     saveMatchBoxState(graphqlField: String! state: JSON!): MatchBoxState
-    saveSet(type: String! userId: String sqon: JSON! path: String! sort: [String]): Set
+    saveSet(type: String! userId: String sqon: JSON! path: String! sort: [Sort]): Set
   }
 
   schema {


### PR DESCRIPTION
Figured out why sets of size >1000 would not create for HCMI data:

1) there's no id field in the hcmi data source, so `path: "id"` fails on `get(x, '_source.${path.split('__').join('.')}')`, so default to `_id`
2) if `path: name` and sort: [`_id`], `search_after` doesnt work properly, it keeps returning pages of 1000 and never reaches the end resulting in an infinite loop. Allow `sort` to be passed in.