### PR TITLE
🐛 parse / display the missing term in a term agg properly

### DIFF
--- a/modules/components/src/Aggs/TermAgg.js
+++ b/modules/components/src/Aggs/TermAgg.js
@@ -8,6 +8,7 @@ import AggsWrapper from './AggsWrapper';
 import TextHighlight from '../TextHighlight';
 import './TermAgg.css';
 import ToggleButton from '../ToggleButton';
+import internalTranslateSQONValue from '../utils/translateSQONValue';
 
 const generateNextSQON = ({ dotField, bucket, isExclude, sqon }) =>
   toggleSQON(
@@ -176,7 +177,7 @@ class TermAgg extends React.Component {
                     />
                     <TextHighlight
                       content={
-                        truncate(bucket.name, {
+                        truncate(internalTranslateSQONValue(bucket.name), {
                           length: valueCharacterLimit || Infinity,
                         }) + ' '
                       }

--- a/modules/components/src/Arranger/CurrentSQON.js
+++ b/modules/components/src/Arranger/CurrentSQON.js
@@ -1,8 +1,10 @@
 import React from 'react';
+import { compose } from 'recompose';
 import Component from 'react-component-component';
 
 import SQONView, { Value, Bubble, Field } from '../SQONView';
 import { fetchExtendedMapping } from '../utils/api';
+import internalTranslateSQONValue from '../utils/translateSQONValue';
 
 export const CurrentSQON = ({
   sqon,
@@ -22,7 +24,7 @@ export const CurrentSQON = ({
     )}
     ValueCrumb={({ field, value, nextSQON, ...props }) => (
       <Value onClick={() => setSQON(nextSQON)} {...props}>
-        {translateSQONValue(
+        {compose(translateSQONValue, internalTranslateSQONValue)(
           (findExtendedMappingField(field)?.displayValues || {})[value] ||
             value,
         )}

--- a/modules/components/src/Arranger/QuickSearch/QuickSearch.js
+++ b/modules/components/src/Arranger/QuickSearch/QuickSearch.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { css } from 'emotion';
-import { uniq } from 'lodash';
 import { compose, withState } from 'recompose';
 import SearchIcon from 'react-icons/lib/fa/search';
 
@@ -10,6 +9,7 @@ import TextInput from '../../Input';
 import TextHighlight from '../../TextHighlight';
 import QuickSearchQuery from './QuickSearchQuery';
 import QuickSearchFieldsQuery from './QuickSearchFieldsQuery';
+import internalTranslateSQONValue from '../../utils/translateSQONValue';
 
 const currentValues = ({ sqon, primaryKeyField }) =>
   currentFieldValue({ sqon, dotField: primaryKeyField?.field, op: 'in' });
@@ -80,7 +80,9 @@ const QuickSearch = ({
                       })
                     }
                   >
-                    {translateSQONValue(primaryKey)}
+                    {compose(translateSQONValue, internalTranslateSQONValue)(
+                      primaryKey,
+                    )}
                   </PinnedValueComponent>
                 </div>
               ))}

--- a/modules/components/src/utils/translateSQONValue.js
+++ b/modules/components/src/utils/translateSQONValue.js
@@ -1,0 +1,6 @@
+export default value => {
+  if (value === '__missing__') {
+    return 'Missing';
+  }
+  return value;
+};

--- a/modules/mapping-utils/src/resolveAggregations.js
+++ b/modules/mapping-utils/src/resolveAggregations.js
@@ -35,7 +35,6 @@ export default type => async (
     _source: false,
     body,
   });
-  console.log(JSON.stringify(body, null, 2));
   const aggregations = flattenAggregations({
     aggregations: response.aggregations,
     includeMissing: include_missing,

--- a/modules/mapping-utils/src/resolveAggregations.js
+++ b/modules/mapping-utils/src/resolveAggregations.js
@@ -35,6 +35,7 @@ export default type => async (
     _source: false,
     body,
   });
+  console.log(JSON.stringify(body, null, 2));
   const aggregations = flattenAggregations({
     aggregations: response.aggregations,
     includeMissing: include_missing,

--- a/modules/middleware/src/buildAggregations.js
+++ b/modules/middleware/src/buildAggregations.js
@@ -32,7 +32,10 @@ function removeFieldFromQuery({ field, query }) {
   const nestedQuery = get(nested, ES_QUERY);
   const bool = get(query, ES_BOOL);
 
-  if (['terms', 'range'].some(k => get(query, [k, field]))) {
+  if (
+    ['terms', 'range'].some(k => get(query, [k, field])) ||
+    get(query, ['exists', 'field']) === field
+  ) {
     return null;
   } else if (nestedQuery) {
     const cleaned = removeFieldFromQuery({ field, query: nestedQuery });
@@ -112,6 +115,10 @@ function wrapWithFilters({
     const cleanedQuery = removeFieldFromQuery({ field, query });
     // TODO: better way to figure out that the field wasn't found
     if (!isEqual(cleanedQuery || {}, query || {})) {
+      console.log('---------------------------------------');
+      console.log(JSON.stringify(cleanedQuery, null, 2));
+      console.log(JSON.stringify(query, null, 2));
+      console.log('---------------------------------------');
       return createGlobalAggregation({
         field,
         aggregation: createFilteredAggregation({

--- a/modules/middleware/src/buildAggregations.js
+++ b/modules/middleware/src/buildAggregations.js
@@ -115,10 +115,6 @@ function wrapWithFilters({
     const cleanedQuery = removeFieldFromQuery({ field, query });
     // TODO: better way to figure out that the field wasn't found
     if (!isEqual(cleanedQuery || {}, query || {})) {
-      console.log('---------------------------------------');
-      console.log(JSON.stringify(cleanedQuery, null, 2));
-      console.log(JSON.stringify(query, null, 2));
-      console.log('---------------------------------------');
       return createGlobalAggregation({
         field,
         aggregation: createFilteredAggregation({

--- a/modules/middleware/src/buildQuery/normalizeFilters.js
+++ b/modules/middleware/src/buildQuery/normalizeFilters.js
@@ -6,6 +6,9 @@ import {
   NOT_OP,
   OP_ALIASES,
   ARRAY_CONTENT,
+  REGEX,
+  SET_ID,
+  MISSING,
 } from '../constants';
 
 function groupingOptimizer({ op, content }) {
@@ -21,7 +24,7 @@ function groupingOptimizer({ op, content }) {
 }
 
 function isSpecialFilter(value) {
-  return ['*', 'set_id:'].some(x => `${value}`.includes(x));
+  return [REGEX, SET_ID, MISSING].some(x => `${value}`.includes(x));
 }
 
 function normalizeFilters(filter) {

--- a/modules/middleware/src/constants.js
+++ b/modules/middleware/src/constants.js
@@ -6,11 +6,15 @@ export const FILTER_OP = 'filter';
 export const AND_OP = 'and';
 export const OR_OP = 'or';
 export const NOT_OP = 'not';
-export const MISSING_OP = 'missing';
 export const GT_OP = 'gt';
 export const GTE_OP = 'gte';
 export const LT_OP = 'lt';
 export const LTE_OP = 'lte';
+
+// special values
+export const REGEX = '*';
+export const MISSING = '__missing__';
+export const SET_ID = 'set_id:';
 
 // sqon op aliases
 export const OP_ALIASES = {

--- a/modules/middleware/src/flattenAggregations.js
+++ b/modules/middleware/src/flattenAggregations.js
@@ -1,5 +1,5 @@
 import { get } from 'lodash';
-import { HISTOGRAM, STATS } from './constants';
+import { HISTOGRAM, STATS, MISSING } from './constants';
 
 function flattenAggregations({ aggregations, includeMissing = true }) {
   return Object.entries(aggregations).reduce((prunedAggs, [key, value]) => {
@@ -16,7 +16,7 @@ function flattenAggregations({ aggregations, includeMissing = true }) {
       const missing = get(aggregations, [`${field}:missing`]);
       const buckets = [
         ...value.buckets,
-        ...(includeMissing && missing ? [{ ...missing, key: '_missing' }] : []),
+        ...(includeMissing && missing ? [{ ...missing, key: MISSING }] : []),
       ];
       return {
         ...prunedAggs,

--- a/modules/middleware/test/buildQuery/buildQuery.test.js
+++ b/modules/middleware/test/buildQuery/buildQuery.test.js
@@ -35,6 +35,31 @@ test('buildQuery "and" and "or" ops', () => {
         bool: { should: [{ terms: { boost: 0, project_code: ['ACC'] } }] },
       },
     },
+    {
+      input: {
+        nestedFields: [],
+        filters: {
+          op: 'or',
+          content: [
+            {
+              op: 'in',
+              content: { field: 'project_code', value: ['__missing__'] },
+            },
+          ],
+        },
+      },
+      output: {
+        bool: {
+          should: [
+            {
+              bool: {
+                must_not: [{ exists: { boost: 0, field: 'project_code' } }],
+              },
+            },
+          ],
+        },
+      },
+    },
   ];
 
   tests.forEach(({ input, output }) => {
@@ -549,122 +574,6 @@ test('buildQuery "=" and "!=" ops', () => {
         },
       },
       output: { terms: { case_count: [24601], boost: 0 } },
-    },
-  ];
-
-  tests.forEach(({ input, output }) => {
-    const actualOutput = buildQuery(input);
-    expect(actualOutput).toEqual(output);
-  });
-});
-
-test('buildQuery missing', () => {
-  const tests = [
-    {
-      input: {
-        nestedFields: [],
-        filters: {
-          op: 'missing',
-          content: {
-            field: 'cases.clinical.gender',
-            value: false,
-          },
-        },
-      },
-      output: { exists: { boost: 0, field: 'cases.clinical.gender' } },
-    },
-    {
-      input: {
-        nestedFields: [],
-        filters: {
-          op: 'and',
-          content: [
-            {
-              op: 'missing',
-              content: {
-                field: 'cases.clinical.gender',
-                value: true,
-              },
-            },
-            {
-              op: 'missing',
-              content: {
-                field: 'cases.clinical.gender',
-                value: false,
-              },
-            },
-          ],
-        },
-      },
-      output: {
-        bool: {
-          must: [
-            {
-              bool: {
-                must_not: [
-                  { exists: { boost: 0, field: 'cases.clinical.gender' } },
-                ],
-              },
-            },
-            { exists: { boost: 0, field: 'cases.clinical.gender' } },
-          ],
-        },
-      },
-    },
-    {
-      input: {
-        nestedFields: [],
-        filters: {
-          op: 'or',
-          content: [
-            {
-              op: 'missing',
-              content: {
-                field: 'cases.clinical.gender',
-                value: true,
-              },
-            },
-            {
-              op: 'missing',
-              content: {
-                field: 'cases.clinical.gender',
-                value: false,
-              },
-            },
-          ],
-        },
-      },
-      output: {
-        bool: {
-          should: [
-            {
-              bool: {
-                must_not: [
-                  { exists: { boost: 0, field: 'cases.clinical.gender' } },
-                ],
-              },
-            },
-            { exists: { boost: 0, field: 'cases.clinical.gender' } },
-          ],
-        },
-      },
-    },
-    {
-      input: {
-        nestedFields: [],
-        filters: {
-          op: 'missing',
-          content: {
-            field: 'cases.clinical.gender',
-            value: true,
-          },
-        },
-      },
-      output: {
-        bool: {
-          must_not: [{ exists: { boost: 0, field: 'cases.clinical.gender' } }],
-        },
-      },
     },
   ];
 

--- a/modules/middleware/test/buildQuery/buildQueryNested.test.js
+++ b/modules/middleware/test/buildQuery/buildQueryNested.test.js
@@ -187,9 +187,9 @@ test('buildQuery "missing" nested', () => {
             {
               content: {
                 field: 'files.analysis.metadata.read_groups.is_paired_end',
-                value: false,
+                value: ['__missing__'],
               },
-              op: 'missing',
+              op: 'in',
             },
           ],
           op: 'and',
@@ -217,6 +217,8 @@ test('buildQuery "missing" nested', () => {
                           'files.experimental_strategy': ['WXS'],
                         },
                       },
+                    ],
+                    must_not: [
                       {
                         exists: {
                           field:
@@ -1264,9 +1266,9 @@ test('buildQuery "=" and "!=" nested', () => {
             {
               content: {
                 field: 'files.analysis.metadata.read_groups.is_paired_end',
-                value: true,
+                value: ['__missing__'],
               },
-              op: 'missing',
+              op: 'in',
             },
           ],
           op: 'and',

--- a/modules/middleware/test/flattenAggregations.test.js
+++ b/modules/middleware/test/flattenAggregations.test.js
@@ -81,7 +81,7 @@ test('flattenAggregations', () => {
         status: {
           buckets: [
             { key: 'legacy', doc_count: 34 },
-            { key: '_missing', doc_count: 1 },
+            { key: '__missing__', doc_count: 1 },
           ],
         },
       },
@@ -134,7 +134,7 @@ test('flattenAggregations', () => {
         'samples.is_ffpe': {
           buckets: [
             { key: 'a', doc_count: 7 },
-            { key: '_missing', doc_count: 5 },
+            { key: '__missing__', doc_count: 5 },
           ],
         },
       },
@@ -165,7 +165,7 @@ test('flattenAggregations', () => {
         'samples.portions.amount': {
           buckets: [
             { key: 'a', doc_count: 7 },
-            { key: '_missing', doc_count: 5 },
+            { key: '__missing__', doc_count: 5 },
           ],
         },
       },
@@ -203,13 +203,13 @@ test('flattenAggregations', () => {
         'samples.portions.amount': {
           buckets: [
             { key: 'a', doc_count: 7 },
-            { key: '_missing', doc_count: 5 },
+            { key: '__missing__', doc_count: 5 },
           ],
         },
         'samples.is_ffpe': {
           buckets: [
             { key: 'a', doc_count: 7 },
-            { key: '_missing', doc_count: 5 },
+            { key: '__missing__', doc_count: 5 },
           ],
         },
       },
@@ -258,13 +258,13 @@ test('flattenAggregations', () => {
         'samples.portions.amount': {
           buckets: [
             { key: 'a', doc_count: 7 },
-            { key: '_missing', doc_count: 5 },
+            { key: '__missing__', doc_count: 5 },
           ],
         },
         'samples.is_ffpe': {
           buckets: [
             { key: 'a', doc_count: 7 },
-            { key: '_missing', doc_count: 5 },
+            { key: '__missing__', doc_count: 5 },
           ],
         },
       },


### PR DESCRIPTION
a few things here:
1) rather than missing being its own operation, it's now a 'special' term in an `in` operation, the special term being `__missing__`
2) added a case so it won't filter itself in aggs
3) added a function to translate `__missing__` to `Missing` in the UI