### PR TITLE
✨ download tsv sort

### DIFF
--- a/modules/server/src/download/index.js
+++ b/modules/server/src/download/index.js
@@ -16,7 +16,7 @@ export default function({ projectId, io }) {
       ...columnsToGraphql({
         sqon: args.sqon,
         config: { columns: args.columns, type: args.index },
-        sort: [],
+        sort: args.sort || [],
         first: 1000,
       }),
     }).pipe(dataToTSV(args));

--- a/modules/server/src/utils/dataToTSV.js
+++ b/modules/server/src/utils/dataToTSV.js
@@ -90,17 +90,16 @@ export function columnsToHeader({ columns }) {
 }
 
 export function dataToTSV({ data, index, uniqueBy, columns, emptyValue }) {
-  return (
-    flatten(
-      get(data, `data['${index}'].hits.edges`, []).map(row => {
-        return getRows({
-          row: row.node,
-          paths: (uniqueBy || '').split('[].').filter(Boolean),
-          columns: columns,
-        }).map(row => row.map(r => r || emptyValue).join('\t'));
-      }),
-    ).join('\n') + '\n'
+  const results = flatten(
+    get(data, `data['${index}'].hits.edges`, []).map(row => {
+      return getRows({
+        row: row.node,
+        paths: (uniqueBy || '').split('[].').filter(Boolean),
+        columns: columns,
+      }).map(row => row.map(r => r || emptyValue).join('\t'));
+    }),
   );
+  return results.length ? results.join('\n') + '\n' : '';
 }
 
 export default function({ columns, index, uniqueBy, emptyValue = '--' }) {


### PR DESCRIPTION
two things:
- allow client to specify sort on download. sort arg matches the typedef `Sort` in the gql schema
- don't pollute the tsv with extra blank lines if `dataToTSV` finds no rows