### PR TITLE
DataTable: allow pass in initialSelectedTableRows

### DIFF
--- a/modules/components/src/Arranger/Table.js
+++ b/modules/components/src/Arranger/Table.js
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import DataTable, { ColumnsState } from '../DataTable';
+import Spinner from 'react-spinkit';
 
 const Table = ({
   projectId,
@@ -18,7 +19,9 @@ const Table = ({
       graphqlField={graphqlField}
       api={api}
       render={columnState => {
-        return (
+        return columnState.loading ? (
+          <Spinner fadeIn="full" name="circle" />
+        ) : (
           <DataTable
             {...{ ...props, api }}
             projectId={projectId}

--- a/modules/components/src/DataTable/ColumnsState.js
+++ b/modules/components/src/DataTable/ColumnsState.js
@@ -28,7 +28,7 @@ export default class extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      config: { keyField: 'id', columns: [], type: props.graphqlField },
+      config: null,
       extended: [],
       toggled: {},
     };
@@ -63,7 +63,11 @@ export default class extends Component {
       });
 
       const config = data[graphqlField].columnsState.state;
-      let { data: { [this.props.graphqlField]: { extended } } } = await api({
+      let {
+        data: {
+          [this.props.graphqlField]: { extended },
+        },
+      } = await api({
         endpoint: `/${this.props.projectId}/graphql`,
         body: {
           query: `
@@ -161,24 +165,30 @@ export default class extends Component {
   render() {
     let { config, extended, toggled } = this.state;
 
-    return this.props.render({
-      update: this.update,
-      add: this.add,
-      toggle: this.toggle,
-      saveOrder: this.saveOrder,
-      state: {
-        ...config,
-        columns: config.columns.map(column => {
-          const extendedField = extended.find(e => e.field === column.field);
-          return {
-            ...column,
-            Header: extendedField?.displayName || column.field,
-            extendedType: extendedField?.type,
-            show: column.field in toggled ? toggled[column.field] : column.show,
-            extendedDisplayValues: extendedField?.displayValues,
-          };
-        }),
-      },
-    });
+    return config
+      ? this.props.render({
+          loading: false,
+          update: this.update,
+          add: this.add,
+          toggle: this.toggle,
+          saveOrder: this.saveOrder,
+          state: {
+            ...config,
+            columns: config.columns.map(column => {
+              const extendedField = extended.find(
+                e => e.field === column.field,
+              );
+              return {
+                ...column,
+                Header: extendedField?.displayName || column.field,
+                extendedType: extendedField?.type,
+                show:
+                  column.field in toggled ? toggled[column.field] : column.show,
+                extendedDisplayValues: extendedField?.displayValues,
+              };
+            }),
+          },
+        })
+      : this.props.render({ loading: true });
   }
 }

--- a/modules/components/src/DataTable/DataTable.js
+++ b/modules/components/src/DataTable/DataTable.js
@@ -49,6 +49,7 @@ class DataTable extends React.Component {
       onSortedChange = () => {},
       alwaysSorted = [],
       initalSelectedTableRows = [],
+      keepSelectedOnPageChange = false,
     } = this.props;
     const { page, pageSize, total } = this.state;
 
@@ -90,6 +91,7 @@ class DataTable extends React.Component {
           maxPagesOptions={maxPagesOptions}
           alwaysSorted={alwaysSorted}
           initalSelectedTableRows={initalSelectedTableRows}
+          keepSelectedOnPageChange={keepSelectedOnPageChange}
         />
       </>
     );

--- a/modules/components/src/DataTable/DataTable.js
+++ b/modules/components/src/DataTable/DataTable.js
@@ -48,6 +48,7 @@ class DataTable extends React.Component {
       downloadUrl = urlJoin(ARRANGER_API, projectId, 'download'),
       onSortedChange = () => {},
       alwaysSorted = [],
+      initalSelectedTableRows = [],
     } = this.props;
     const { page, pageSize, total } = this.state;
 
@@ -88,6 +89,7 @@ class DataTable extends React.Component {
           loading={loading}
           maxPagesOptions={maxPagesOptions}
           alwaysSorted={alwaysSorted}
+          initalSelectedTableRows={initalSelectedTableRows}
         />
       </>
     );

--- a/modules/components/src/DataTable/Table/Table.js
+++ b/modules/components/src/DataTable/Table/Table.js
@@ -17,7 +17,7 @@ class DataTable extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      selectedTableRows: [],
+      selectedTableRows: props.initalSelectedTableRows || [],
       data: [],
       pages: -1,
       loading: false,

--- a/modules/components/src/DataTable/Table/Table.js
+++ b/modules/components/src/DataTable/Table/Table.js
@@ -51,7 +51,13 @@ class DataTable extends React.Component {
 
   // QUESTION: onFetchData? isn't this doing the actual fetching
   onFetchData = state => {
-    const { fetchData, config, sqon, alwaysSorted = [] } = this.props;
+    const {
+      fetchData,
+      config,
+      sqon,
+      alwaysSorted = [],
+      keepSelectedOnPageChange,
+    } = this.props;
     const { selectedTableRows } = this.state;
 
     this.setState({ loading: true, lastState: state });
@@ -82,12 +88,14 @@ class DataTable extends React.Component {
           loading: false,
         });
 
-        this.setSelectedTableRows(
-          intersection(
-            data.map(item => item[this.props.config.keyField]),
-            selectedTableRows,
-          ),
-        );
+        if (!keepSelectedOnPageChange) {
+          this.setSelectedTableRows(
+            intersection(
+              data.map(item => item[this.props.config.keyField]),
+              selectedTableRows,
+            ),
+          );
+        }
       })
       .catch(err => {
         console.error(err);


### PR DESCRIPTION
- prevent DataTable rendering when ColumnState is not loaded so that
  fetch with no config does not occur overriding initialSelectedTableRows