### PR TITLE
🐛 keep term agg in view on collapse

### DIFF
--- a/modules/components/package-lock.json
+++ b/modules/components/package-lock.json
@@ -1,27 +1,15 @@
 {
   "name": "@arranger/components",
-<<<<<<< HEAD
   "version": "0.3.27",
-=======
-  "version": "0.3.29",
->>>>>>> 98e755b... :bug: some handling for null column state
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@arranger/mapping-utils": {
-<<<<<<< HEAD
       "version": "0.3.27",
       "resolved": "https://registry.npmjs.org/@arranger/mapping-utils/-/mapping-utils-0.3.27.tgz",
       "integrity": "sha512-ANUZLScQLGqd+oz667W/kkL1vxwcI6TF7TUs3qqiUHrxPavpLsxC+k+aqMtyBKfa7wUdk7ZrTbxOtQlnGdcB9A==",
       "requires": {
         "@arranger/middleware": "0.3.27",
-=======
-      "version": "0.3.29",
-      "resolved": "https://registry.npmjs.org/@arranger/mapping-utils/-/mapping-utils-0.3.29.tgz",
-      "integrity": "sha512-WzXZOKV42xIxwwcEDBh57l0M/bGQcPo+OQM3qxHFpzrzZEjtjV1d4KKKmdEz4WYVVxm/AWVL9qLTKKzh6kJJcA==",
-      "requires": {
-        "@arranger/middleware": "0.3.29",
->>>>>>> 98e755b... :bug: some handling for null column state
         "babel-polyfill": "6.26.0",
         "elasticsearch": "14.2.2",
         "graphql-fields": "1.0.2",
@@ -31,15 +19,9 @@
       }
     },
     "@arranger/middleware": {
-<<<<<<< HEAD
       "version": "0.3.27",
       "resolved": "https://registry.npmjs.org/@arranger/middleware/-/middleware-0.3.27.tgz",
       "integrity": "sha512-CHh27sCbEA34QpxWvMm4MweMeUU8PUhqeaYGXBTpykreAXma3CMfdqvQLEqROnQnHVEXwYf/GV5F1iOyX9l01g==",
-=======
-      "version": "0.3.29",
-      "resolved": "https://registry.npmjs.org/@arranger/middleware/-/middleware-0.3.29.tgz",
-      "integrity": "sha512-n15mwew/NgEX5UWV9qL+aN7Z8uADzi6XgaUAi1bcygFBQ+HAHrPGaZm1iop+gd0Z8m0Nj3g4AcOQVFmXQiEFiQ==",
->>>>>>> 98e755b... :bug: some handling for null column state
       "requires": {
         "body-parser": "1.18.2",
         "cors": "2.8.4",

--- a/modules/components/package-lock.json
+++ b/modules/components/package-lock.json
@@ -1,15 +1,27 @@
 {
   "name": "@arranger/components",
+<<<<<<< HEAD
   "version": "0.3.27",
+=======
+  "version": "0.3.29",
+>>>>>>> 98e755b... :bug: some handling for null column state
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@arranger/mapping-utils": {
+<<<<<<< HEAD
       "version": "0.3.27",
       "resolved": "https://registry.npmjs.org/@arranger/mapping-utils/-/mapping-utils-0.3.27.tgz",
       "integrity": "sha512-ANUZLScQLGqd+oz667W/kkL1vxwcI6TF7TUs3qqiUHrxPavpLsxC+k+aqMtyBKfa7wUdk7ZrTbxOtQlnGdcB9A==",
       "requires": {
         "@arranger/middleware": "0.3.27",
+=======
+      "version": "0.3.29",
+      "resolved": "https://registry.npmjs.org/@arranger/mapping-utils/-/mapping-utils-0.3.29.tgz",
+      "integrity": "sha512-WzXZOKV42xIxwwcEDBh57l0M/bGQcPo+OQM3qxHFpzrzZEjtjV1d4KKKmdEz4WYVVxm/AWVL9qLTKKzh6kJJcA==",
+      "requires": {
+        "@arranger/middleware": "0.3.29",
+>>>>>>> 98e755b... :bug: some handling for null column state
         "babel-polyfill": "6.26.0",
         "elasticsearch": "14.2.2",
         "graphql-fields": "1.0.2",
@@ -19,9 +31,15 @@
       }
     },
     "@arranger/middleware": {
+<<<<<<< HEAD
       "version": "0.3.27",
       "resolved": "https://registry.npmjs.org/@arranger/middleware/-/middleware-0.3.27.tgz",
       "integrity": "sha512-CHh27sCbEA34QpxWvMm4MweMeUU8PUhqeaYGXBTpykreAXma3CMfdqvQLEqROnQnHVEXwYf/GV5F1iOyX9l01g==",
+=======
+      "version": "0.3.29",
+      "resolved": "https://registry.npmjs.org/@arranger/middleware/-/middleware-0.3.29.tgz",
+      "integrity": "sha512-n15mwew/NgEX5UWV9qL+aN7Z8uADzi6XgaUAi1bcygFBQ+HAHrPGaZm1iop+gd0Z8m0Nj3g4AcOQVFmXQiEFiQ==",
+>>>>>>> 98e755b... :bug: some handling for null column state
       "requires": {
         "body-parser": "1.18.2",
         "cors": "2.8.4",

--- a/modules/components/src/Admin/Tabs/Aggregations/TableTab.js
+++ b/modules/components/src/Admin/Tabs/Aggregations/TableTab.js
@@ -13,30 +13,36 @@ export default ({ projectId, graphqlField }) => (
           flexDirection: 'row',
         }}
       >
-        <div style={{ flex: 1 }}>
-          <EditColumns
-            handleChange={columnsState.update}
-            addColumn={columnsState.add}
-            {...columnsState}
-          />
-        </div>
-        <div>
-          <strong>Columns order</strong>
-          <DraggableListOrderer
-            {...{
-              itemsList: columnsState.state.columns.map(
-                ({ show, ...rest }) => ({
-                  active: show,
-                  ...rest,
-                }),
-              ),
-              projectId,
-              graphqlField,
-              onOrderChange: newItemList =>
-                columnsState.saveOrder(newItemList.map(({ field }) => field)),
-            }}
-          />
-        </div>
+        {!columnsState.loading && (
+          <React.Fragment>
+            <div style={{ flex: 1 }}>
+              <EditColumns
+                handleChange={columnsState.update}
+                addColumn={columnsState.add}
+                {...columnsState}
+              />
+            </div>
+            <div>
+              <strong>Columns order</strong>
+              <DraggableListOrderer
+                {...{
+                  itemsList: columnsState.state.columns.map(
+                    ({ show, ...rest }) => ({
+                      active: show,
+                      ...rest,
+                    }),
+                  ),
+                  projectId,
+                  graphqlField,
+                  onOrderChange: newItemList =>
+                    columnsState.saveOrder(
+                      newItemList.map(({ field }) => field),
+                    ),
+                }}
+              />
+            </div>
+          </React.Fragment>
+        )}
       </div>
     )}
   />

--- a/modules/components/src/Admin/Tabs/Aggregations/TableTab.js
+++ b/modules/components/src/Admin/Tabs/Aggregations/TableTab.js
@@ -14,7 +14,7 @@ export default ({ projectId, graphqlField }) => (
         }}
       >
         {!columnsState.loading && (
-          <React.Fragment>
+          <>
             <div style={{ flex: 1 }}>
               <EditColumns
                 handleChange={columnsState.update}
@@ -41,7 +41,7 @@ export default ({ projectId, graphqlField }) => (
                 }}
               />
             </div>
-          </React.Fragment>
+          </>
         )}
       </div>
     )}

--- a/modules/components/src/Aggs/AggsWrapper.js
+++ b/modules/components/src/Aggs/AggsWrapper.js
@@ -12,15 +12,16 @@ export default ({
   filters,
   WrapperComponent,
   ActionIcon = null,
+  componentRef,
 }) => {
   return WrapperComponent ? (
-    <WrapperComponent {...{ collapsible, displayName }}>
+    <WrapperComponent {...{ collapsible, displayName, componentRef }}>
       {children}
     </WrapperComponent>
   ) : (
     <Component initialState={{ isCollapsed: false }}>
       {({ setState, state: { isCollapsed } }) => (
-        <div className="aggregation-card">
+        <div className="aggregation-card" ref={componentRef}>
           <div
             className={`header ${css`
               position: ${stickyHeader ? `sticky` : `relative`};

--- a/modules/components/src/Aggs/AggsWrapper.js
+++ b/modules/components/src/Aggs/AggsWrapper.js
@@ -13,6 +13,7 @@ export default ({
   WrapperComponent,
   ActionIcon = null,
   componentRef,
+  headerRef,
 }) => {
   return WrapperComponent ? (
     <WrapperComponent {...{ collapsible, displayName, componentRef }}>
@@ -23,6 +24,7 @@ export default ({
       {({ setState, state: { isCollapsed } }) => (
         <div className="aggregation-card" ref={componentRef}>
           <div
+            ref={headerRef}
             className={`header ${css`
               position: ${stickyHeader ? `sticky` : `relative`};
               top: 0px;

--- a/modules/components/src/Aggs/AggsWrapper.js
+++ b/modules/components/src/Aggs/AggsWrapper.js
@@ -16,7 +16,9 @@ export default ({
   headerRef,
 }) => {
   return WrapperComponent ? (
-    <WrapperComponent {...{ collapsible, displayName, componentRef }}>
+    <WrapperComponent
+      {...{ collapsible, displayName, componentRef, headerRef }}
+    >
       {children}
     </WrapperComponent>
   ) : (

--- a/modules/components/src/Aggs/TermAgg.js
+++ b/modules/components/src/Aggs/TermAgg.js
@@ -102,6 +102,13 @@ const TermAgg = ({
   searchPlaceholder = 'Search',
   containerRef,
   aggWrapperRef = React.createRef(),
+  aggHeaderRef = React.createRef(),
+  scrollToAgg = () => {
+    if (containerRef?.current)
+      containerRef.current.scrollTop =
+        aggWrapperRef.current.offsetTop -
+        aggHeaderRef.current.getBoundingClientRect().height;
+  },
 
   // Internal State
   stateShowingMore,
@@ -130,6 +137,7 @@ const TermAgg = ({
   return (
     <AggsWrapper
       componentRef={aggWrapperRef}
+      headerRef={aggHeaderRef}
       stickyHeader
       {...{ displayName, WrapperComponent, collapsible }}
       ActionIcon={
@@ -159,10 +167,8 @@ const TermAgg = ({
                       isMore={false}
                       onClick={() => {
                         setShowingMore(false);
-                        if (containerRef?.current) {
-                          containerRef.current.scrollTop =
-                            aggWrapperRef.current.offsetTop;
-                        }
+                        setShowingSearch(false);
+                        scrollToAgg();
                       }}
                     />
                   )}
@@ -246,6 +252,7 @@ const TermAgg = ({
             onClick={() => {
               setShowingMore(!showingMore);
               setShowingSearch(!showingMore);
+              if (showingMore) scrollToAgg();
             }}
             howManyMore={decoratedBuckets.length - maxTerms}
           />

--- a/modules/components/src/Aggs/TermAgg.js
+++ b/modules/components/src/Aggs/TermAgg.js
@@ -100,6 +100,8 @@ const TermAgg = ({
   highlightText,
   constructBucketItemClassName = () => '',
   searchPlaceholder = 'Search',
+  containerRef,
+  aggWrapperRef = React.createRef(),
 
   // Internal State
   stateShowingMore,
@@ -127,6 +129,7 @@ const TermAgg = ({
   const isMoreEnabled = decoratedBuckets.length > maxTerms;
   return (
     <AggsWrapper
+      componentRef={aggWrapperRef}
       stickyHeader
       {...{ displayName, WrapperComponent, collapsible }}
       ActionIcon={
@@ -154,7 +157,13 @@ const TermAgg = ({
                   isMoreEnabled && (
                     <MoreOrLessButton
                       isMore={false}
-                      onClick={() => setShowingMore(false)}
+                      onClick={() => {
+                        setShowingMore(false);
+                        if (containerRef?.current) {
+                          containerRef.current.scrollTop =
+                            aggWrapperRef.current.offsetTop;
+                        }
+                      }}
                     />
                   )}
               </>,

--- a/modules/components/src/Arranger/Aggregations.js
+++ b/modules/components/src/Arranger/Aggregations.js
@@ -16,6 +16,7 @@ const Aggregations = ({
   style,
   api,
   Wrapper = BaseWrapper,
+  containerRef,
 }) => {
   return (
     <Wrapper style={style} className={className}>
@@ -42,15 +43,12 @@ const Aggregations = ({
                     ...data[graphqlField].extended.find(
                       x => x.field.replace(/\./g, '__') === agg.field,
                     ),
+                    onValueChange: ({ sqon }) => setSQON(sqon),
+                    key: agg.field,
+                    sqon,
+                    containerRef,
                   }))
-                  .map(agg =>
-                    aggComponents[agg.type]?.({
-                      onValueChange: ({ sqon }) => setSQON(sqon),
-                      key: agg.field,
-                      sqon,
-                      ...agg,
-                    }),
-                  )
+                  .map(agg => aggComponents[agg.type]?.(agg))
               }
             />
           );

--- a/modules/components/src/DataTable/ColumnsState.js
+++ b/modules/components/src/DataTable/ColumnsState.js
@@ -63,11 +63,7 @@ export default class extends Component {
       });
 
       const config = data[graphqlField].columnsState.state;
-      let {
-        data: {
-          [this.props.graphqlField]: { extended },
-        },
-      } = await api({
+      let { data: { [this.props.graphqlField]: { extended } } } = await api({
         endpoint: `/${this.props.projectId}/graphql`,
         body: {
           query: `
@@ -164,7 +160,6 @@ export default class extends Component {
 
   render() {
     let { config, extended, toggled } = this.state;
-
     return config
       ? this.props.render({
           loading: false,
@@ -189,6 +184,6 @@ export default class extends Component {
             }),
           },
         })
-      : this.props.render({ loading: true });
+      : this.props.render({ loading: true, state: { config: null } });
   }
 }


### PR DESCRIPTION
2 things here:
 - changes to columnstate broke some stuff in KF / arranger admin, so put in some safety checks for that
 - when clicking 'less' on the term agg they want the term agg to stay in agg view (in a 'scrolling' aggregation sidebar context)