### PR TITLE
🐛 range agg fixes

### DIFF
--- a/modules/components/public/themeStyles/beagle/beagle.css
+++ b/modules/components/public/themeStyles/beagle/beagle.css
@@ -562,6 +562,7 @@ div {
   color: #2b388f;
 }
 
+.aggregation-card .toggle-button .bucket-count,
 .facetViewWrapper .bucket-count {
   border-radius: 5px;
   background-color: #e7e8ed;

--- a/modules/components/src/Aggs/RangeAgg.css
+++ b/modules/components/src/Aggs/RangeAgg.css
@@ -17,11 +17,11 @@
 .input-range-wrapper {
   margin-left: 25px;
   margin-right: 25px;
-  margin-top: 20px;
-  margin-bottom: 15px;
+  margin-top: 25px;
+  position: relative;
+  font-size: 0.8rem;
 }
 
 .input-range__label {
-  font-family: inherit !important;
-  color: inherit !important;
+  display: none;
 }

--- a/modules/components/src/Aggs/RangeAgg.js
+++ b/modules/components/src/Aggs/RangeAgg.js
@@ -20,6 +20,19 @@ const supportedConversionFromUnit = unit =>
 
 const round = x => Math.round(x * 100) / 100;
 
+const RangeLabel = ({ children, isTop, isLeft, ...props }) => (
+  <div
+    {...props}
+    css={`
+      position: absolute;
+      ${isLeft ? `left` : `right`}: 0;
+      top: ${isTop ? `-` : ``}1.2rem;
+    `}
+  >
+    {children}
+  </div>
+);
+
 class RangeAgg extends Component {
   constructor(props) {
     super(props);
@@ -132,6 +145,10 @@ class RangeAgg extends Component {
                   ))}
             </div>
             <div className="input-range-wrapper">
+              <RangeLabel isTop isLeft>
+                {this.formatRangeLabel(value.min)}
+              </RangeLabel>
+              <RangeLabel isTop>{this.formatRangeLabel(value.max)}</RangeLabel>
               <InputRange
                 draggableTrack
                 step={step}
@@ -142,6 +159,8 @@ class RangeAgg extends Component {
                 onChange={x => this.setValue(x)}
                 onChangeComplete={this.onChangeComplete}
               />
+              <RangeLabel isLeft>{this.formatRangeLabel(min)}</RangeLabel>
+              <RangeLabel>{this.formatRangeLabel(max)}</RangeLabel>
             </div>
           </div>
         )}

--- a/modules/components/src/Aggs/RangeAgg.js
+++ b/modules/components/src/Aggs/RangeAgg.js
@@ -23,9 +23,8 @@ const round = x => Math.round(x * 100) / 100;
 class RangeAgg extends Component {
   constructor(props) {
     super(props);
-    let { field, stats: { min, max }, unit, value } = props;
+    let { stats: { min, max }, unit, value } = props;
     this.state = {
-      field,
       min,
       max,
       unit: unit,
@@ -38,29 +37,21 @@ class RangeAgg extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    let { field, stats: { min, max } } = this.props;
-    const { value: externalVal } = nextProps;
+    const { stats: { min, max }, value: externalVal } = nextProps;
     let { value } = this.state;
     this.setState({
-      field,
       min,
       max,
       value: {
-        min: Math.max(
-          !_.isNil(externalVal?.min) ? externalVal.min : value.min,
-          min,
-        ),
-        max: Math.min(
-          !_.isNil(externalVal?.max) ? externalVal.max : value.max,
-          max,
-        ),
+        min: Math.max(externalVal?.min || value.min, min),
+        max: Math.min(externalVal?.max || value.max, max),
       },
     });
   }
 
   onChangeComplete = () => {
-    let { handleChange } = this.props;
-    let { field, value } = this.state;
+    let { field, handleChange } = this.props;
+    let { value } = this.state;
     const [min, max] = [value.min, value.max].map(x => round(x));
     handleChange?.({
       field,


### PR DESCRIPTION
Changes:
- range agg stats were behind one prop cycle
- field from state 'cause why was it there in the first place
- locked range agg values to four corners around the slider, because values kept overlapping / colliding
- fixed boolean agg bucket count CSS
