### PR TITLE
Propagate the selected facet/agg value up to the highest parent component

### DIFF
--- a/modules/components/src/Aggs/BooleanAgg.js
+++ b/modules/components/src/Aggs/BooleanAgg.js
@@ -1,9 +1,9 @@
-import React from "react";
-import AggsWrapper from "./AggsWrapper.js";
-import { replaceSQON, removeSQON } from "../SQONView/utils";
-import "./BooleanAgg.css";
-import TextHighlight from "../TextHighlight";
-import ToggleButton from "../ToggleButton";
+import React from 'react';
+import AggsWrapper from './AggsWrapper.js';
+import { replaceSQON, removeSQON } from '../SQONView/utils';
+import './BooleanAgg.css';
+import TextHighlight from '../TextHighlight';
+import ToggleButton from '../ToggleButton';
 
 export default ({
   field,
@@ -15,42 +15,42 @@ export default ({
   displayName,
   highlightText,
   valueKeys = {
-    true: "true",
-    false: "false"
+    true: 'true',
+    false: 'false',
   },
   defaultDisplayKeys = {
-    any: "Any",
-    true: "Yes",
-    false: "No"
+    any: 'Any',
+    true: 'Yes',
+    false: 'No',
   },
   displayValues: extendedDisplayKeys = {},
   displayKeys = Object.keys(defaultDisplayKeys).reduce(
     (obj, x) => ({
       ...obj,
-      [x]: extendedDisplayKeys[x] || defaultDisplayKeys[x]
+      [x]: extendedDisplayKeys[x] || defaultDisplayKeys[x],
     }),
-    {}
+    {},
   ),
   ...rest
 }) => {
   const trueBucket = buckets.find(
-    ({ key_as_string }) => key_as_string === valueKeys.true
+    ({ key_as_string }) => key_as_string === valueKeys.true,
   );
   const falseBucket = buckets.find(
-    ({ key_as_string }) => key_as_string === valueKeys.false
+    ({ key_as_string }) => key_as_string === valueKeys.false,
   );
 
   const missingKeyBucket = buckets.find(({ key_as_string }) => !key_as_string);
 
-  const dotField = field.replace(/__/g, ".");
+  const dotField = field.replace(/__/g, '.');
 
   const isTrueActive = isActive({
     value: valueKeys.true,
-    field: dotField
+    field: dotField,
   });
   const isFalseActive = isActive({
     value: valueKeys.false,
-    field: dotField
+    field: dotField,
   });
 
   const handleChange = (isTrue, field) => {
@@ -62,25 +62,25 @@ export default ({
         generateNextSQON: sqon =>
           replaceSQON(
             {
-              op: "and",
+              op: 'and',
               content: [
                 {
-                  op: "in",
+                  op: 'in',
                   content: {
                     field: dotField,
-                    value: [valueKeys[isTrue ? "true" : "false"]]
-                  }
-                }
-              ]
+                    value: [valueKeys[isTrue ? 'true' : 'false']],
+                  },
+                },
+              ],
             },
-            sqon
-          )
+            sqon,
+          ),
       });
     } else {
       handleValueClick({
-        value: "Any",
+        value: 'Any',
         field,
-        generateNextSQON: sqon => removeSQON(dotField, sqon)
+        generateNextSQON: sqon => removeSQON(dotField, sqon),
       });
     }
   };
@@ -95,7 +95,7 @@ export default ({
           options: [
             {
               value: undefined,
-              title: displayKeys.any
+              title: displayKeys.any,
             },
             {
               value: valueKeys.true,
@@ -109,14 +109,14 @@ export default ({
                     <span
                       className={`bucket-count`}
                       style={{
-                        marginLeft: 2
+                        marginLeft: 2,
                       }}
                     >
                       {trueBucket.doc_count}
                     </span>
                   )}
                 </>
-              )
+              ),
             },
             {
               value: valueKeys.false,
@@ -130,24 +130,24 @@ export default ({
                     <span
                       className={`bucket-count`}
                       style={{
-                        marginLeft: 2
+                        marginLeft: 2,
                       }}
                     >
                       {falseBucket.doc_count}
                     </span>
                   )}
                 </>
-              )
-            }
+              ),
+            },
           ],
           onChange: ({ value }) => {
             handleChange(
               value === valueKeys.true
                 ? true
                 : value === valueKeys.false ? false : undefined,
-              dotField
+              dotField,
             );
-          }
+          },
         }}
       />
     </AggsWrapper>

--- a/modules/components/src/Aggs/BooleanAgg.js
+++ b/modules/components/src/Aggs/BooleanAgg.js
@@ -1,9 +1,9 @@
-import React from 'react';
-import AggsWrapper from './AggsWrapper.js';
-import { replaceSQON, removeSQON } from '../SQONView/utils';
-import './BooleanAgg.css';
-import TextHighlight from '../TextHighlight';
-import ToggleButton from '../ToggleButton';
+import React from "react";
+import AggsWrapper from "./AggsWrapper.js";
+import { replaceSQON, removeSQON } from "../SQONView/utils";
+import "./BooleanAgg.css";
+import TextHighlight from "../TextHighlight";
+import ToggleButton from "../ToggleButton";
 
 export default ({
   field,
@@ -15,66 +15,72 @@ export default ({
   displayName,
   highlightText,
   valueKeys = {
-    true: 'true',
-    false: 'false',
+    true: "true",
+    false: "false"
   },
   defaultDisplayKeys = {
-    any: 'Any',
-    true: 'Yes',
-    false: 'No',
+    any: "Any",
+    true: "Yes",
+    false: "No"
   },
   displayValues: extendedDisplayKeys = {},
   displayKeys = Object.keys(defaultDisplayKeys).reduce(
     (obj, x) => ({
       ...obj,
-      [x]: extendedDisplayKeys[x] || defaultDisplayKeys[x],
+      [x]: extendedDisplayKeys[x] || defaultDisplayKeys[x]
     }),
-    {},
+    {}
   ),
   ...rest
 }) => {
   const trueBucket = buckets.find(
-    ({ key_as_string }) => key_as_string === valueKeys.true,
+    ({ key_as_string }) => key_as_string === valueKeys.true
   );
   const falseBucket = buckets.find(
-    ({ key_as_string }) => key_as_string === valueKeys.false,
+    ({ key_as_string }) => key_as_string === valueKeys.false
   );
-  const dotField = field.replace(/__/g, '.');
+
+  const missingKeyBucket = buckets.find(({ key_as_string }) => !key_as_string);
+
+  const dotField = field.replace(/__/g, ".");
 
   const isTrueActive = isActive({
     value: valueKeys.true,
-    field: dotField,
+    field: dotField
   });
   const isFalseActive = isActive({
     value: valueKeys.false,
-    field: dotField,
+    field: dotField
   });
 
-  const handleChange = isTrue => {
+  const handleChange = (isTrue, field) => {
     if (isTrue !== undefined) {
       handleValueClick({
         bucket: isTrue ? trueBucket : falseBucket,
+        value: isTrue ? trueBucket : falseBucket || missingKeyBucket,
+        field,
         generateNextSQON: sqon =>
           replaceSQON(
             {
-              op: 'and',
+              op: "and",
               content: [
                 {
-                  op: 'in',
+                  op: "in",
                   content: {
                     field: dotField,
-                    value: [valueKeys[isTrue ? 'true' : 'false']],
-                  },
-                },
-              ],
+                    value: [valueKeys[isTrue ? "true" : "false"]]
+                  }
+                }
+              ]
             },
-            sqon,
-          ),
+            sqon
+          )
       });
     } else {
       handleValueClick({
-        bucket: null,
-        generateNextSQON: sqon => removeSQON(dotField, sqon),
+        value: "Any",
+        field,
+        generateNextSQON: sqon => removeSQON(dotField, sqon)
       });
     }
   };
@@ -85,13 +91,11 @@ export default ({
         {...{
           value: isTrueActive
             ? valueKeys.true
-            : isFalseActive
-              ? valueKeys.false
-              : undefined,
+            : isFalseActive ? valueKeys.false : undefined,
           options: [
             {
               value: undefined,
-              title: displayKeys.any,
+              title: displayKeys.any
             },
             {
               value: valueKeys.true,
@@ -105,14 +109,14 @@ export default ({
                     <span
                       className={`bucket-count`}
                       style={{
-                        marginLeft: 2,
+                        marginLeft: 2
                       }}
                     >
                       {trueBucket.doc_count}
                     </span>
                   )}
                 </>
-              ),
+              )
             },
             {
               value: valueKeys.false,
@@ -126,25 +130,24 @@ export default ({
                     <span
                       className={`bucket-count`}
                       style={{
-                        marginLeft: 2,
+                        marginLeft: 2
                       }}
                     >
                       {falseBucket.doc_count}
                     </span>
                   )}
                 </>
-              ),
-            },
+              )
+            }
           ],
           onChange: ({ value }) => {
             handleChange(
               value === valueKeys.true
                 ? true
-                : value === valueKeys.false
-                  ? false
-                  : undefined,
+                : value === valueKeys.false ? false : undefined,
+              dotField
             );
-          },
+          }
         }}
       />
     </AggsWrapper>

--- a/modules/components/src/Aggs/DatesAgg.js
+++ b/modules/components/src/Aggs/DatesAgg.js
@@ -67,6 +67,8 @@ class DatesAgg extends React.Component {
           : []),
       ];
       handleDateChange({
+        field,
+        value: content,
         generateNextSQON: sqon =>
           replaceSQON(
             content.length ? { op: 'and', content } : null,

--- a/modules/components/src/Aggs/RangeAgg.js
+++ b/modules/components/src/Aggs/RangeAgg.js
@@ -1,18 +1,18 @@
-import React, { Component } from 'react';
-import InputRange from 'react-input-range';
-import convert from 'convert-units';
-import _ from 'lodash';
+import React, { Component } from "react";
+import InputRange from "react-input-range";
+import convert from "convert-units";
+import _ from "lodash";
 
-import { replaceSQON } from '../SQONView/utils';
-import AggsWrapper from './AggsWrapper';
+import { replaceSQON } from "../SQONView/utils";
+import AggsWrapper from "./AggsWrapper";
 
-import 'react-input-range/lib/css/index.css';
-import './AggregationCard.css';
-import './RangeAgg.css';
+import "react-input-range/lib/css/index.css";
+import "./AggregationCard.css";
+import "./RangeAgg.css";
 
 const SUPPORTED_CONVERSIONS = {
-  time: ['d', 'year'],
-  digital: ['GB'],
+  time: ["d", "year"],
+  digital: ["GB"]
 };
 
 const supportedConversionFromUnit = unit =>
@@ -44,8 +44,8 @@ class RangeAgg extends Component {
       displayUnit: supportedConversionFromUnit(unit)?.[0],
       value: {
         min: !_.isNil(value) ? value.min || min : min,
-        max: !_.isNil(value) ? value.max || max : max,
-      },
+        max: !_.isNil(value) ? value.max || max : max
+      }
     };
   }
 
@@ -57,30 +57,36 @@ class RangeAgg extends Component {
       max,
       value: {
         min: Math.max(externalVal?.min || value.min, min),
-        max: Math.min(externalVal?.max || value.max, max),
-      },
+        max: Math.min(externalVal?.max || value.max, max)
+      }
     });
   }
 
   onChangeComplete = () => {
-    let { field, handleChange } = this.props;
-    let { value } = this.state;
+    let { field, handleChange, displayName } = this.props;
+    let { value, displayUnit } = this.state;
     const [min, max] = [value.min, value.max].map(x => round(x));
+
     handleChange?.({
-      field,
+      field: {
+        displayName,
+        displayUnit,
+        field,
+      },
+      value,
       min,
       max,
       generateNextSQON: sqon =>
         replaceSQON(
           {
-            op: 'and',
+            op: "and",
             content: [
-              { op: '>=', content: { field, value: min } },
-              { op: '<=', content: { field, value: max } },
-            ],
+              { op: ">=", content: { field, value: min } },
+              { op: "<=", content: { field, value: max } }
+            ]
           },
-          sqon,
-        ),
+          sqon
+        )
     });
   };
 
@@ -101,7 +107,7 @@ class RangeAgg extends Component {
       ? Math.round(
           convert(value)
             .from(unit)
-            .to(displayUnit) * 100,
+            .to(displayUnit) * 100
         ) / 100
       : value;
   };
@@ -109,9 +115,9 @@ class RangeAgg extends Component {
   render() {
     let {
       step,
-      displayName = 'Unnamed Field',
+      displayName = "Unnamed Field",
       collapsible = true,
-      WrapperComponent,
+      WrapperComponent
     } = this.props;
     let { min, max, value, unit, displayUnit } = this.state;
     const supportedConversions = supportedConversionFromUnit(unit);

--- a/modules/components/src/Aggs/TermAgg.js
+++ b/modules/components/src/Aggs/TermAgg.js
@@ -220,6 +220,7 @@ const TermAgg = ({
                 }}
                 onClick={() =>
                   handleValueClick({
+                    dotField,
                     bucket,
                     isExclude,
                     generateNextSQON: sqon =>

--- a/modules/components/src/Aggs/TermAgg.js
+++ b/modules/components/src/Aggs/TermAgg.js
@@ -220,8 +220,8 @@ const TermAgg = ({
                 }}
                 onClick={() =>
                   handleValueClick({
-                    dotField,
-                    bucket,
+                    field: dotField,
+                    value: bucket,
                     isExclude,
                     generateNextSQON: sqon =>
                       generateNextSQON({ isExclude, dotField, bucket, sqon }),

--- a/modules/components/src/Aggs/aggComponentsMap.js
+++ b/modules/components/src/Aggs/aggComponentsMap.js
@@ -75,8 +75,19 @@ const composedBooleanAgg = ({ sqon, onValueChange, ...rest }) => (
         currentSQON: sqon
       })
     }
-    handleValueClick={({ generateNextSQON }) => {
-      onValueChange({ sqon: generateNextSQON(sqon) });
+    handleValueClick={({ generateNextSQON, value, field }) => {
+      const nextSQON = generateNextSQON(sqon);
+      onValueChange({
+        sqon: nextSQON,
+        value: {
+          value,
+          field,
+          active: fieldInCurrentSQON({
+            currentSQON: nextSQON ? nextSQON.content : [],
+            field: field
+          })
+        }
+      });
     }}
     {...rest}
   />

--- a/modules/components/src/Aggs/aggComponentsMap.js
+++ b/modules/components/src/Aggs/aggComponentsMap.js
@@ -1,18 +1,29 @@
-import React from 'react';
-import { TermAgg, RangeAgg, BooleanAgg, DatesAgg } from '../Aggs';
-import { currentFieldValue } from '../SQONView/utils';
-import { inCurrentSQON } from '../SQONView/utils';
+import React from "react";
+import { TermAgg, RangeAgg, BooleanAgg, DatesAgg } from "../Aggs";
+import { currentFieldValue } from "../SQONView/utils";
+import { inCurrentSQON } from "../SQONView/utils";
 
 const composedTermAgg = ({ sqon, onValueChange, ...rest }) => (
   <TermAgg
-    handleValueClick={({ generateNextSQON }) => {
-      onValueChange({ sqon: generateNextSQON(sqon) });
+    handleValueClick={({ generateNextSQON, bucket, dotField }) => {
+      onValueChange({
+        sqon: generateNextSQON(sqon),
+        value: { 
+          dotField, 
+          bucket,
+          active: inCurrentSQON({
+            value: bucket.name,
+            dotField,
+            currentSQON: generateNextSQON(sqon),
+          })
+        }
+      });
     }}
     isActive={d =>
       inCurrentSQON({
         value: d.value,
         dotField: d.field,
-        currentSQON: sqon,
+        currentSQON: sqon
       })
     }
     {...rest}
@@ -23,13 +34,13 @@ const composedRangeAgg = ({ sqon, onValueChange, field, stats, ...rest }) => (
   <RangeAgg
     value={{
       min:
-        currentFieldValue({ sqon, dotField: field, op: '>=' }) ||
+        currentFieldValue({ sqon, dotField: field, op: ">=" }) ||
         stats?.min ||
         0,
       max:
-        currentFieldValue({ sqon, dotField: field, op: '<=' }) ||
+        currentFieldValue({ sqon, dotField: field, op: "<=" }) ||
         stats?.max ||
-        0,
+        0
     }}
     handleChange={({ generateNextSQON }) =>
       onValueChange({ sqon: generateNextSQON(sqon) })
@@ -44,7 +55,7 @@ const composedBooleanAgg = ({ sqon, onValueChange, ...rest }) => (
       inCurrentSQON({
         value: d.value,
         dotField: d.field,
-        currentSQON: sqon,
+        currentSQON: sqon
       })
     }
     handleValueClick={({ generateNextSQON }) => {
@@ -63,7 +74,7 @@ const composedDatesAgg = ({ sqon, onValueChange, ...rest }) => (
       currentFieldValue({
         op,
         dotField: field,
-        sqon,
+        sqon
       })
     }
     {...rest}
@@ -76,5 +87,5 @@ export default {
   float: composedRangeAgg,
   boolean: composedBooleanAgg,
   date: composedDatesAgg,
-  integer: composedRangeAgg,
+  integer: composedRangeAgg
 };

--- a/modules/components/src/Aggs/aggComponentsMap.js
+++ b/modules/components/src/Aggs/aggComponentsMap.js
@@ -95,9 +95,20 @@ const composedBooleanAgg = ({ sqon, onValueChange, ...rest }) => (
 
 const composedDatesAgg = ({ sqon, onValueChange, ...rest }) => (
   <DatesAgg
-    handleDateChange={({ generateNextSQON = () => {} } = {}) =>
-      onValueChange({ sqon: generateNextSQON(sqon) })
-    }
+    handleDateChange={({ generateNextSQON = () => {}, field, value } = {}) => {
+      const nextSQON = generateNextSQON(sqon);
+      onValueChange({
+        sqon: nextSQON,
+        value: {
+          field,
+          value,
+          active: fieldInCurrentSQON({
+            currentSQON: nextSQON ? nextSQON.content : [],
+            field: field
+          })
+        }
+      });
+    }}
     getActiveValue={({ op, field }) =>
       currentFieldValue({
         op,

--- a/modules/components/src/Aggs/aggComponentsMap.js
+++ b/modules/components/src/Aggs/aggComponentsMap.js
@@ -2,19 +2,20 @@ import React from "react";
 import { TermAgg, RangeAgg, BooleanAgg, DatesAgg } from "../Aggs";
 import { currentFieldValue } from "../SQONView/utils";
 import { inCurrentSQON } from "../SQONView/utils";
+import { fieldInCurrentSQON } from "../SQONView/utils";
 
 const composedTermAgg = ({ sqon, onValueChange, ...rest }) => (
   <TermAgg
-    handleValueClick={({ generateNextSQON, bucket, dotField }) => {
+    handleValueClick={({ generateNextSQON, value, field }) => {
       onValueChange({
         sqon: generateNextSQON(sqon),
-        value: { 
-          dotField, 
-          bucket,
+        value: {
+          field,
+          value,
           active: inCurrentSQON({
-            value: bucket.name,
-            dotField,
-            currentSQON: generateNextSQON(sqon),
+            value: value.name,
+            field,
+            currentSQON: generateNextSQON(sqon)
           })
         }
       });
@@ -42,9 +43,25 @@ const composedRangeAgg = ({ sqon, onValueChange, field, stats, ...rest }) => (
         stats?.max ||
         0
     }}
-    handleChange={({ generateNextSQON }) =>
-      onValueChange({ sqon: generateNextSQON(sqon) })
-    }
+    handleChange={({
+      generateNextSQON,
+      field: { displayName, displayUnit, field },
+      value
+    }) => {
+      const nextSQON = generateNextSQON(sqon);
+
+      onValueChange({
+        sqon: nextSQON,
+        value: {
+          field: `${displayName} (${displayUnit})`,
+          value,
+          active: fieldInCurrentSQON({
+            currentSQON: nextSQON.content,
+            field: field
+          })
+        }
+      });
+    }}
     {...{ ...rest, stats, field }}
   />
 );

--- a/modules/components/src/Aggs/aggComponentsMap.js
+++ b/modules/components/src/Aggs/aggComponentsMap.js
@@ -1,8 +1,8 @@
-import React from "react";
-import { TermAgg, RangeAgg, BooleanAgg, DatesAgg } from "../Aggs";
-import { currentFieldValue } from "../SQONView/utils";
-import { inCurrentSQON } from "../SQONView/utils";
-import { fieldInCurrentSQON } from "../SQONView/utils";
+import React from 'react';
+import { TermAgg, RangeAgg, BooleanAgg, DatesAgg } from '../Aggs';
+import { currentFieldValue } from '../SQONView/utils';
+import { inCurrentSQON } from '../SQONView/utils';
+import { fieldInCurrentSQON } from '../SQONView/utils';
 
 const composedTermAgg = ({ sqon, onValueChange, ...rest }) => (
   <TermAgg
@@ -15,16 +15,16 @@ const composedTermAgg = ({ sqon, onValueChange, ...rest }) => (
           active: inCurrentSQON({
             value: value.name,
             field,
-            currentSQON: generateNextSQON(sqon)
-          })
-        }
+            currentSQON: generateNextSQON(sqon),
+          }),
+        },
       });
     }}
     isActive={d =>
       inCurrentSQON({
         value: d.value,
         dotField: d.field,
-        currentSQON: sqon
+        currentSQON: sqon,
       })
     }
     {...rest}
@@ -35,18 +35,18 @@ const composedRangeAgg = ({ sqon, onValueChange, field, stats, ...rest }) => (
   <RangeAgg
     value={{
       min:
-        currentFieldValue({ sqon, dotField: field, op: ">=" }) ||
+        currentFieldValue({ sqon, dotField: field, op: '>=' }) ||
         stats?.min ||
         0,
       max:
-        currentFieldValue({ sqon, dotField: field, op: "<=" }) ||
+        currentFieldValue({ sqon, dotField: field, op: '<=' }) ||
         stats?.max ||
-        0
+        0,
     }}
     handleChange={({
       generateNextSQON,
       field: { displayName, displayUnit, field },
-      value
+      value,
     }) => {
       const nextSQON = generateNextSQON(sqon);
 
@@ -57,9 +57,9 @@ const composedRangeAgg = ({ sqon, onValueChange, field, stats, ...rest }) => (
           value,
           active: fieldInCurrentSQON({
             currentSQON: nextSQON.content,
-            field: field
-          })
-        }
+            field: field,
+          }),
+        },
       });
     }}
     {...{ ...rest, stats, field }}
@@ -72,7 +72,7 @@ const composedBooleanAgg = ({ sqon, onValueChange, ...rest }) => (
       inCurrentSQON({
         value: d.value,
         dotField: d.field,
-        currentSQON: sqon
+        currentSQON: sqon,
       })
     }
     handleValueClick={({ generateNextSQON, value, field }) => {
@@ -84,9 +84,9 @@ const composedBooleanAgg = ({ sqon, onValueChange, ...rest }) => (
           field,
           active: fieldInCurrentSQON({
             currentSQON: nextSQON ? nextSQON.content : [],
-            field: field
-          })
-        }
+            field: field,
+          }),
+        },
       });
     }}
     {...rest}
@@ -104,16 +104,16 @@ const composedDatesAgg = ({ sqon, onValueChange, ...rest }) => (
           value,
           active: fieldInCurrentSQON({
             currentSQON: nextSQON ? nextSQON.content : [],
-            field: field
-          })
-        }
+            field: field,
+          }),
+        },
       });
     }}
     getActiveValue={({ op, field }) =>
       currentFieldValue({
         op,
         dotField: field,
-        sqon
+        sqon,
       })
     }
     {...rest}
@@ -126,5 +126,5 @@ export default {
   float: composedRangeAgg,
   boolean: composedBooleanAgg,
   date: composedDatesAgg,
-  integer: composedRangeAgg
+  integer: composedRangeAgg,
 };

--- a/modules/components/src/Arranger/Aggregations.js
+++ b/modules/components/src/Arranger/Aggregations.js
@@ -1,22 +1,23 @@
-import React from 'react';
+import React from "react";
 
-import { AggsState, AggsQuery } from '../Aggs';
-import aggComponents from '../Aggs/aggComponentsMap.js';
+import { AggsState, AggsQuery } from "../Aggs";
+import aggComponents from "../Aggs/aggComponentsMap.js";
 
 const BaseWrapper = ({ className, ...props }) => (
   <div {...props} className={`aggregations ${className}`} />
 );
 
 const Aggregations = ({
+  onTermSelected = () => {},
   setSQON,
   sqon,
   projectId,
   graphqlField,
-  className = '',
+  className = "",
   style,
   api,
   Wrapper = BaseWrapper,
-  containerRef,
+  containerRef
 }) => {
   return (
     <Wrapper style={style} className={className}>
@@ -41,12 +42,15 @@ const Aggregations = ({
                     ...agg,
                     ...data[graphqlField].aggregations[agg.field],
                     ...data[graphqlField].extended.find(
-                      x => x.field.replace(/\./g, '__') === agg.field,
+                      x => x.field.replace(/\./g, "__") === agg.field
                     ),
-                    onValueChange: ({ sqon }) => setSQON(sqon),
+                    onValueChange: ({ sqon, value }) => {
+                      setSQON(sqon);
+                      onTermSelected(value);
+                    },
                     key: agg.field,
                     sqon,
-                    containerRef,
+                    containerRef
                   }))
                   .map(agg => aggComponents[agg.type]?.(agg))
               }

--- a/modules/components/src/Arranger/Aggregations.js
+++ b/modules/components/src/Arranger/Aggregations.js
@@ -1,7 +1,7 @@
-import React from "react";
+import React from 'react';
 
-import { AggsState, AggsQuery } from "../Aggs";
-import aggComponents from "../Aggs/aggComponentsMap.js";
+import { AggsState, AggsQuery } from '../Aggs';
+import aggComponents from '../Aggs/aggComponentsMap.js';
 
 const BaseWrapper = ({ className, ...props }) => (
   <div {...props} className={`aggregations ${className}`} />
@@ -13,11 +13,11 @@ const Aggregations = ({
   sqon,
   projectId,
   graphqlField,
-  className = "",
+  className = '',
   style,
   api,
   Wrapper = BaseWrapper,
-  containerRef
+  containerRef,
 }) => {
   return (
     <Wrapper style={style} className={className}>
@@ -42,7 +42,7 @@ const Aggregations = ({
                     ...agg,
                     ...data[graphqlField].aggregations[agg.field],
                     ...data[graphqlField].extended.find(
-                      x => x.field.replace(/\./g, "__") === agg.field
+                      x => x.field.replace(/\./g, '__') === agg.field,
                     ),
                     onValueChange: ({ sqon, value }) => {
                       setSQON(sqon);
@@ -50,7 +50,7 @@ const Aggregations = ({
                     },
                     key: agg.field,
                     sqon,
-                    containerRef
+                    containerRef,
                   }))
                   .map(agg => aggComponents[agg.type]?.(agg))
               }


### PR DESCRIPTION
When a user interacts with a facet/aggregation value propagate that call and it's value up to the highest parent component to allow for hooks into these events