### PR TITLE
✨ need graphql context options as well

### DIFF
--- a/modules/server/src/projects/index.js
+++ b/modules/server/src/projects/index.js
@@ -13,7 +13,7 @@ import addProject from './addProject';
 import getProjects from './getProjects';
 import updateField from './updateField';
 
-export default ({ io, graphqlMiddleware }) => {
+export default ({ io, graphqlOptions }) => {
   const router = express.Router();
   // create es client
   router.use('/', async (req, res, next) => {
@@ -36,7 +36,7 @@ export default ({ io, graphqlMiddleware }) => {
   router.use('/:id/types/:index/delete', deleteType);
   router.use('/:id/types/:index/fields', getFields);
   router.use('/:id/types/add', addType);
-  router.use('/:id/spinUp', spinUp({ io, graphqlMiddleware }));
+  router.use('/:id/spinUp', spinUp({ io, graphqlOptions }));
   router.use('/:id/teardown', teardown);
   router.use('/:id/types', getTypes);
   router.use('/:id/delete', deleteProject);

--- a/modules/server/src/projects/spinUp.js
+++ b/modules/server/src/projects/spinUp.js
@@ -1,11 +1,11 @@
 import startProject from '../startProject';
 
-export default ({ io, graphqlMiddleware }) => async (req, res) => {
+export default ({ io, graphqlOptions }) => async (req, res) => {
   let { es } = req.context;
   let { id } = req.params;
 
   try {
-    startProject({ es, id, io, graphqlMiddleware });
+    startProject({ es, id, io, graphqlOptions });
   } catch (err) {
     return res.json({ error: err.message });
   }

--- a/modules/server/src/server.js
+++ b/modules/server/src/server.js
@@ -9,9 +9,9 @@ import startProject from './startProject';
 import { ES_HOST, PROJECT_ID, MAX_LIVE_VERSIONS } from './utils/config';
 import { fetchProjects } from './projects/getProjects';
 
-let startSingleProject = async ({ io, projectId, es, graphqlMiddleware }) => {
+let startSingleProject = async ({ io, projectId, es, graphqlOptions }) => {
   try {
-    await startProject({ es, io, id: projectId, graphqlMiddleware });
+    await startProject({ es, io, id: projectId, graphqlOptions });
   } catch (error) {
     console.warn(error.message);
   }
@@ -21,7 +21,7 @@ export default async ({
   projectId = PROJECT_ID,
   esHost = ES_HOST,
   io,
-  graphqlMiddleware = [],
+  graphqlOptions = {},
 } = {}) => {
   const router = express.Router();
   router.use(bodyParser.json({ limit: '50mb' }));
@@ -41,11 +41,11 @@ export default async ({
     next();
   });
 
-  router.use('/projects', projectsRoutes({ io, graphqlMiddleware }));
+  router.use('/projects', projectsRoutes({ io, graphqlOptions }));
   if (esHost) {
     const es = new elasticsearch.Client({ host: esHost });
     if (projectId) {
-      startSingleProject({ io, projectId, es, graphqlMiddleware });
+      startSingleProject({ io, projectId, es, graphqlOptions });
     } else {
       const { projects = [] } = await fetchProjects({ es });
 
@@ -59,7 +59,7 @@ export default async ({
                 io,
                 projectId: project.id,
                 es,
-                graphqlMiddleware,
+                graphqlOptions,
               });
             } catch (error) {
               console.warn(error.message);


### PR DESCRIPTION
so my last middleware PR wasn't enough, we need to be able to populate graphql context as well, in order to have access to the user information in the resolver middleware.

I've tested this locally, am 90% sure this gives us what we'll need to properly protect resolvers from KF-arranger