### PR TITLE
🐛 passes refresh to saveSet, defaulting to "WAIT_FOR"

### DIFF
--- a/modules/mapping-utils/src/resolveSets.js
+++ b/modules/mapping-utils/src/resolveSets.js
@@ -51,7 +51,7 @@ const retrieveSetIds = async ({
 
 export const saveSet = ({ types }) => async (
   obj,
-  { type, userId, sqon, path, sort },
+  { type, userId, sqon, path, sort, refresh = 'WAIT_FOR' },
   { es, projectId, io },
 ) => {
   const { nested_fields: nestedFields, es_type, index } = types.find(
@@ -82,6 +82,7 @@ export const saveSet = ({ types }) => async (
     index: CONSTANTS.ES_ARRANGER_SET_INDEX,
     type: CONSTANTS.ES_ARRANGER_SET_TYPE,
     id: body.setId,
+    refresh: refresh.toLowerCase(),
     body,
   });
 

--- a/modules/schema/src/Root.js
+++ b/modules/schema/src/Root.js
@@ -17,6 +17,11 @@ import { typeDefs as StateTypeDefs } from './State';
 let RootTypeDefs = ({ types, rootTypes, scalarTypes }) => `
   scalar JSON
   scalar Date
+  enum EsRefresh {
+    TRUE
+    FALSE
+    WAIT_FOR
+  }
 
   ${scalarTypes.map(([type]) => `scalar ${type}`)}
 
@@ -48,7 +53,7 @@ let RootTypeDefs = ({ types, rootTypes, scalarTypes }) => `
     saveAggsState(graphqlField: String! state: JSON!): AggsState
     saveColumnsState(graphqlField: String! state: JSON!): ColumnsState
     saveMatchBoxState(graphqlField: String! state: JSON!): MatchBoxState
-    saveSet(type: String! userId: String sqon: JSON! path: String! sort: [Sort]): Set
+    saveSet(type: String! userId: String sqon: JSON! path: String! sort: [Sort] refresh: EsRefresh): Set
   }
 
   schema {


### PR DESCRIPTION
`refresh` flag as layed out here: https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/current/api-reference.html#api-index