### PR TITLE
✨import/export arranger config

### DIFF
--- a/modules/components/src/Admin/Dashboard.css
+++ b/modules/components/src/Admin/Dashboard.css
@@ -9,12 +9,16 @@
   padding: 10px;
 }
 
-.dashboard label {
+.dashboard .fancy-label {
   letter-spacing: 1px;
   border-bottom: 1px solid;
   margin-bottom: 5px;
   display: inline-block;
   color: #5a8f94;
+}
+
+.dashboard .input-file {
+  font-size: 12px;
 }
 
 .dashboard .title-arranger {

--- a/modules/components/src/Admin/Dashboard.js
+++ b/modules/components/src/Admin/Dashboard.js
@@ -222,6 +222,17 @@ class Dashboard extends React.Component {
               💤
             </div>
           ),
+          export: () => (
+            <div
+              css={`
+                cursor: pointer;
+                text-align: center;
+              `}
+              onClick={() => this.export({ id: x.id })}
+            >
+              📥
+            </div>
+          ),
           endpointStatus: () => (
             <div
               css={`
@@ -418,6 +429,17 @@ class Dashboard extends React.Component {
     });
   };
 
+  export = async ({ id }) => {
+    console.log('id', id);
+    await api({
+      endpoint: `/projects/${id}/export`,
+      body: {
+        eshost: this.state.eshost,
+        id,
+      },
+    });
+  };
+
   redeployServer = async () => {
     await api({
       endpoint: `/restartServer`,
@@ -525,11 +547,7 @@ class Dashboard extends React.Component {
           <Switch>
             <Route
               path="/graphiql/:projectId"
-              render={({
-                match: {
-                  params: { projectId },
-                },
-              }) => (
+              render={({ match: { params: { projectId } } }) => (
                 <Component
                   initialState={{ projectId }}
                   shouldUpdate={({ state }) => state.projectId !== projectId}
@@ -575,9 +593,7 @@ class Dashboard extends React.Component {
               exact
               path={'/:id'}
               render={({
-                match: {
-                  params: { id: projectId },
-                },
+                match: { params: { id: projectId } },
                 history,
                 location,
               }) => (
@@ -649,9 +665,7 @@ class Dashboard extends React.Component {
               exact
               path={'/:projectId/:index'}
               render={({
-                match: {
-                  params: { projectId, index },
-                },
+                match: { params: { projectId, index } },
                 history,
                 location,
                 graphqlField = projects

--- a/modules/components/src/Admin/Dashboard.js
+++ b/modules/components/src/Admin/Dashboard.js
@@ -27,13 +27,13 @@ import AggregationsTab from './Tabs/Aggregations/AggregationsTab';
 import TableTab from './Tabs/Aggregations/TableTab';
 import MatchBoxTab from './Tabs/MatchBoxTab';
 
-const FancyLabel = ({ children, className, ...props }) => (
+export const FancyLabel = ({ children, className, ...props }) => (
   <label className={`fancy-label ${className}`} {...props}>
     {children}
   </label>
 );
 
-const Emoji = ({ label = '', content, ...props }) => (
+export const Emoji = ({ label = '', content, ...props }) => (
   <span aria-label={label} role="img" {...props}>
     {content}
   </span>

--- a/modules/components/src/Admin/Dashboard.js
+++ b/modules/components/src/Admin/Dashboard.js
@@ -17,14 +17,21 @@ import State from '../State';
 import Header from './Header';
 import ProjectsTable from './ProjectsTable';
 import TypesTable from './TypesTable';
-import { ES_HOST } from '../utils/config';
+import { ARRANGER_API, ES_HOST } from '../utils/config';
 import api from '../utils/api';
 import download from '../utils/download';
 import initSocket from '../utils/initSocket';
+import parseInputFiles from '../utils/parseInputFiles';
+
 import AggregationsTab from './Tabs/Aggregations/AggregationsTab';
 import TableTab from './Tabs/Aggregations/TableTab';
 import MatchBoxTab from './Tabs/MatchBoxTab';
-import { ARRANGER_API } from '../utils/config';
+
+const FancyLabel = ({ children, className, ...props }) => (
+  <label className={`fancy-label ${className}`} {...props}>
+    {children}
+  </label>
+);
 
 const Emoji = ({ label = '', content, ...props }) => (
   <span aria-label={label} role="img" {...props}>
@@ -33,6 +40,8 @@ const Emoji = ({ label = '', content, ...props }) => (
 );
 
 class Dashboard extends React.Component {
+  fileRef = React.createRef();
+
   constructor(props) {
     super(props);
 
@@ -53,6 +62,7 @@ class Dashboard extends React.Component {
       newTypeIndex: '',
       newTypeName: '',
       newTypeEsType: '',
+      newTypeConfig: [],
       types: [],
       typesTotal: 0,
       activeType: null,
@@ -393,6 +403,7 @@ class Dashboard extends React.Component {
         index: this.state.newTypeIndex,
         esType: this.state.newTypeEsType,
         name: this.state.newTypeName,
+        config: this.state.newTypeConfig,
       },
     });
 
@@ -405,6 +416,7 @@ class Dashboard extends React.Component {
         this.state.projects,
       );
 
+      this.fileRef.current.value = null;
       this.setState({
         types,
         projects: projectsWithTypes,
@@ -412,6 +424,7 @@ class Dashboard extends React.Component {
         newTypeIndex: '',
         newTypeName: '',
         newTypeEsType: '',
+        newTypeConfig: [],
         error: null,
       });
     }
@@ -662,6 +675,27 @@ class Dashboard extends React.Component {
                             this.setState({ newTypeEsType: e.target.value })
                           }
                         />
+                      </div>
+                      <div>
+                        <label className="input-file">
+                          Config. Files
+                          <input
+                            type="file"
+                            multiple
+                            ref={this.fileRef}
+                            accept="*.json"
+                            onChange={async e =>
+                              this.setState({
+                                newTypeConfig: (await parseInputFiles({
+                                  files: e.target.files,
+                                })).map(f => ({
+                                  name: f.name,
+                                  content: JSON.parse(f.content),
+                                })),
+                              })
+                            }
+                          />
+                        </label>
                         <button onClick={this.addType}>+</button>
                       </div>
                     </>
@@ -757,9 +791,9 @@ class Dashboard extends React.Component {
                           >
                             <section>
                               <div style={{ padding: 5 }}>
-                                <label className="projects">
+                                <FancyLabel className="projects">
                                   FIELDS ({this.state.fieldsTotal})
-                                </label>
+                                </FancyLabel>
                               </div>
                               {this.state.fields
                                 .filter(x => x.field.includes(filterText))
@@ -781,9 +815,9 @@ class Dashboard extends React.Component {
                             </section>
                             <section>
                               <div style={{ padding: 5 }}>
-                                <label className="projects">
+                                <FancyLabel className="projects">
                                   {activeField?.field}
-                                </label>
+                                </FancyLabel>
                               </div>
                               {Object.entries(activeField || {})
                                 .filter(([key]) => key !== 'field')
@@ -818,7 +852,7 @@ class Dashboard extends React.Component {
                                       {key === 'displayValues' ? (
                                         activeField.type === 'boolean' ? (
                                           <div>
-                                            <label>Any: </label>
+                                            <FancyLabel>Any: </FancyLabel>
                                             <input
                                               type="text"
                                               onChange={updateBooleanDisplayValue(
@@ -826,7 +860,7 @@ class Dashboard extends React.Component {
                                               )}
                                               value={val.any}
                                             />
-                                            <label>True: </label>
+                                            <FancyLabel>True: </FancyLabel>
                                             <input
                                               type="text"
                                               onChange={updateBooleanDisplayValue(
@@ -834,7 +868,7 @@ class Dashboard extends React.Component {
                                               )}
                                               value={val.true}
                                             />
-                                            <label>False: </label>
+                                            <FancyLabel>False: </FancyLabel>
                                             <input
                                               type="text"
                                               onChange={updateBooleanDisplayValue(

--- a/modules/components/src/Admin/Dashboard.js
+++ b/modules/components/src/Admin/Dashboard.js
@@ -26,6 +26,12 @@ import TableTab from './Tabs/Aggregations/TableTab';
 import MatchBoxTab from './Tabs/MatchBoxTab';
 import { ARRANGER_API } from '../utils/config';
 
+const Emoji = ({ label = '', content, ...props }) => (
+  <span aria-label={label} role="img" {...props}>
+    {content}
+  </span>
+);
+
 class Dashboard extends React.Component {
   constructor(props) {
     super(props);
@@ -163,7 +169,7 @@ class Dashboard extends React.Component {
               `}
               onClick={() => this.deleteProject({ id: x.id })}
             >
-              🔥
+              <Emoji content="🔥" />
             </div>
           ),
           active: () => (
@@ -173,7 +179,7 @@ class Dashboard extends React.Component {
                 text-align: center;
               `}
             >
-              <span
+              <Emoji
                 onClick={() =>
                   this.updateProjectField({
                     id: x.id,
@@ -184,9 +190,8 @@ class Dashboard extends React.Component {
                 css={`
                   border-bottom: ${x.active ? '2px solid green' : 'none'};
                 `}
-              >
-                ✅
-              </span>{' '}
+                content="✅"
+              />{' '}
               <span
                 onClick={() =>
                   this.updateProjectField({
@@ -211,7 +216,7 @@ class Dashboard extends React.Component {
               `}
               onClick={() => this.spinup({ id: x.id })}
             >
-              ⚡️
+              <Emoji content="⚡️" />
             </div>
           ),
           teardown: () => (
@@ -222,7 +227,7 @@ class Dashboard extends React.Component {
               `}
               onClick={() => this.teardown({ id: x.id })}
             >
-              💤
+              <Emoji content="💤" />
             </div>
           ),
           export: () => (
@@ -233,7 +238,7 @@ class Dashboard extends React.Component {
               `}
               onClick={() => this.export({ id: x.id })}
             >
-              📥
+              <Emoji content="📥" />
             </div>
           ),
           endpointStatus: () => (
@@ -502,7 +507,7 @@ class Dashboard extends React.Component {
                 flex: none;
               `}
             >
-              ⚠️ {error}
+              <Emoji content="⚠️" /> {error}
             </div>
           )}
 
@@ -625,7 +630,7 @@ class Dashboard extends React.Component {
                             this.deleteType({ projectId, index: x.index })
                           }
                         >
-                          🔥
+                          <Emoji content="🔥" />
                         </div>
                       ),
                     }))}

--- a/modules/components/src/Admin/Dashboard.js
+++ b/modules/components/src/Admin/Dashboard.js
@@ -3,6 +3,7 @@ import Component from 'react-component-component';
 import { debounce, startCase, pick } from 'lodash';
 import { BrowserRouter, Route, Link, Redirect, Switch } from 'react-router-dom';
 import convert from 'convert-units';
+import urlJoin from 'url-join';
 
 // TODO: importing this causes "multiple versions" of graphql to be loaded and throw error
 // import GraphiQL from 'graphiql';
@@ -18,10 +19,12 @@ import ProjectsTable from './ProjectsTable';
 import TypesTable from './TypesTable';
 import { ES_HOST } from '../utils/config';
 import api from '../utils/api';
+import download from '../utils/download';
 import initSocket from '../utils/initSocket';
 import AggregationsTab from './Tabs/Aggregations/AggregationsTab';
 import TableTab from './Tabs/Aggregations/TableTab';
 import MatchBoxTab from './Tabs/MatchBoxTab';
+import { ARRANGER_API } from '../utils/config';
 
 class Dashboard extends React.Component {
   constructor(props) {
@@ -430,9 +433,9 @@ class Dashboard extends React.Component {
   };
 
   export = async ({ id }) => {
-    console.log('id', id);
-    await api({
-      endpoint: `/projects/${id}/export`,
+    download({
+      url: urlJoin(ARRANGER_API, `projects`, id, 'export'),
+      method: 'POST',
       body: {
         eshost: this.state.eshost,
         id,

--- a/modules/components/src/Admin/ProjectsTable.js
+++ b/modules/components/src/Admin/ProjectsTable.js
@@ -93,11 +93,19 @@ export default ({
         },
         {
           show: true,
-          Header: 'decomission',
+          Header: 'Decomission',
           type: 'component',
           sortable: false,
           canChangeShow: false,
           accessor: 'teardown',
+        },
+        {
+          show: true,
+          Header: 'Export',
+          type: 'component',
+          sortable: false,
+          canChangeShow: false,
+          accessor: 'export',
         },
       ],
     }}

--- a/modules/components/src/Admin/Tabs/MatchBoxTab.js
+++ b/modules/components/src/Admin/Tabs/MatchBoxTab.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import Component from 'react-component-component';
 
+import { FancyLabel } from '../Dashboard';
 import { MatchBoxState } from '../../MatchBox';
 
 export default ({ projectId, graphqlField }) => (
@@ -42,11 +43,11 @@ export default ({ projectId, graphqlField }) => (
               {activeField && (
                 <section>
                   <div>
-                    <label>Field: </label>
+                    <FancyLabel>Field: </FancyLabel>
                     <span>{activeField.field}</span>
                   </div>
                   <div>
-                    <label>Display Name: </label>
+                    <FancyLabel>Display Name: </FancyLabel>
                     <input
                       type="text"
                       placeholder="Display Name"
@@ -61,7 +62,7 @@ export default ({ projectId, graphqlField }) => (
                     />
                   </div>
                   <div>
-                    <label>Active: </label>
+                    <FancyLabel>Active: </FancyLabel>
                     <input
                       type="checkbox"
                       checked={activeField.isActive}
@@ -75,7 +76,7 @@ export default ({ projectId, graphqlField }) => (
                     />
                   </div>
                   <div>
-                    <label>Key Field:</label>
+                    <FancyLabel>Key Field:</FancyLabel>
                     <select
                       value={activeField.keyField}
                       onChange={({ target: { value } }) =>
@@ -103,7 +104,7 @@ export default ({ projectId, graphqlField }) => (
                     </select>
                   </div>
                   <div>
-                    <label>Search Fields:</label>
+                    <FancyLabel>Search Fields:</FancyLabel>
                     <select
                       value={''}
                       onChange={({ target: { value } }) =>

--- a/modules/components/src/Arranger/MatchBox.js
+++ b/modules/components/src/Arranger/MatchBox.js
@@ -9,6 +9,7 @@ import { MatchBoxState } from '../MatchBox';
 import QuickSearchQuery from './QuickSearch/QuickSearchQuery';
 import saveSet from '../utils/saveSet';
 import formatNumber from '../utils/formatNumber';
+import parseInputFiles from '../utils/parseInputFiles';
 import { toggleSQON } from '../SQONView/utils';
 
 const layoutStyle = css`
@@ -46,21 +47,15 @@ const enhance = compose(
     onTextChange: ({ setSearchText }) => ({ target: { value } }) =>
       setSearchText(value),
     onFileUpload: ({ setSearchText, setSearchTextLoading }) => async ({
-      target,
+      target: { files },
     }) => {
       setSearchTextLoading(true);
-      const contents = await Promise.all(
-        [...target.files].map(
-          f =>
-            new Promise((resolve, reject) => {
-              const reader = new FileReader();
-              reader.onload = () => resolve(reader.result);
-              reader.onerror = e => reject(e);
-              reader.readAsText(f);
-            }),
-        ),
+      const contents = await parseInputFiles({ files });
+      setSearchText(
+        (contents || [])
+          .map(f => f.content)
+          .reduce((str, c) => `${str}${c}\n`, ``),
       );
-      setSearchText((contents || []).reduce((str, c) => `${str}${c}\n`, ``));
       setSearchTextLoading(false);
     },
   }),

--- a/modules/components/src/utils/parseInputFiles.js
+++ b/modules/components/src/utils/parseInputFiles.js
@@ -1,0 +1,13 @@
+export default ({ files }) =>
+  Promise.all(
+    [...files].map(
+      f =>
+        new Promise((resolve, reject) => {
+          const reader = new FileReader();
+          reader.onload = () =>
+            resolve({ name: f.name, content: reader.result });
+          reader.onerror = e => reject(e);
+          reader.readAsText(f);
+        }),
+    ),
+  );

--- a/modules/mapping-utils/src/mappingToMatchBoxState.js
+++ b/modules/mapping-utils/src/mappingToMatchBoxState.js
@@ -4,7 +4,7 @@ const defaults = {
   searchFields: [],
 };
 
-export default ({ name, extendedFields, ...mapping }) => [
+export default ({ name, extendedFields }) => [
   {
     displayName: name,
     field: '',

--- a/modules/server/package-lock.json
+++ b/modules/server/package-lock.json
@@ -4,6 +4,52 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@arranger/mapping-utils": {
+      "version": "0.3.62",
+      "resolved": "https://registry.npmjs.org/@arranger/mapping-utils/-/mapping-utils-0.3.62.tgz",
+      "integrity": "sha512-D1dMbv8/AmlL+7MvnYfvkZiDNowvOJuhhrHqz3pH0Up+PgsXZ7bOqvVWitrUPAkvFUZDgHe/KlUEhmVnHJgTqw==",
+      "requires": {
+        "@arranger/middleware": "0.3.62",
+        "babel-polyfill": "6.26.0",
+        "elasticsearch": "14.1.0",
+        "graphql-fields": "1.0.2",
+        "lodash": "4.17.5",
+        "node-fetch": "2.0.0",
+        "uuid": "3.2.1"
+      }
+    },
+    "@arranger/middleware": {
+      "version": "0.3.62",
+      "resolved": "https://registry.npmjs.org/@arranger/middleware/-/middleware-0.3.62.tgz",
+      "integrity": "sha512-3VHI2J1slpVY2f9AePH/kYQ1D3bRaMjk2CePLL0QEn9a+kiNeF+UcTjexEC5GEcqavClHrYXw+lwRbR3983IUw==",
+      "requires": {
+        "body-parser": "1.18.2",
+        "cors": "2.8.4",
+        "date-fns": "1.29.0",
+        "express": "4.16.2",
+        "lodash": "4.17.5",
+        "morgan": "1.9.0",
+        "utf8": "3.0.0",
+        "winston": "2.4.2"
+      }
+    },
+    "@arranger/schema": {
+      "version": "0.3.62",
+      "resolved": "https://registry.npmjs.org/@arranger/schema/-/schema-0.3.62.tgz",
+      "integrity": "sha512-SDRo/cQTp94yAlmJUQVY5eRyx8SSU4JlAIgGScAD0QPfV+MX21giXZ/lvWfjnixvuMO/RIJz24ZFAKx/cFS2hQ==",
+      "requires": {
+        "@arranger/mapping-utils": "0.3.62",
+        "@arranger/middleware": "0.3.62",
+        "babel-polyfill": "6.26.0",
+        "elasticsearch": "14.1.0",
+        "graphql-middleware": "1.2.6",
+        "graphql-scalars": "0.1.5",
+        "graphql-tools": "2.24.0",
+        "graphql-type-json": "0.1.4",
+        "lodash": "4.17.5",
+        "uuid": "3.2.1"
+      }
+    },
     "@babel/cli": {
       "version": "7.0.0-beta.40",
       "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.0.0-beta.40.tgz",
@@ -708,6 +754,11 @@
         "to-fast-properties": "2.0.0"
       }
     },
+    "@types/node": {
+      "version": "9.6.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.20.tgz",
+      "integrity": "sha512-mIMXUbH2MmJAQQjzFUIRpxa+FtA27IaHMrIgoJ1fyu/EfpVN/UZw3ISMNnwVec4lau8R8SM4pNFXSCZpJFX2Bw=="
+    },
     "JSONSelect": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/JSONSelect/-/JSONSelect-0.4.0.tgz",
@@ -835,6 +886,16 @@
         "graphql-extensions": "0.0.7"
       }
     },
+    "apollo-link": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.1.tgz",
+      "integrity": "sha512-6Ghf+j3cQLCIvjXd2dJrLw+16HZbWbwmB1qlTc41BviB2hv+rK1nJr17Y9dWK0UD4p3i9Hfddx3tthpMKrueHg==",
+      "requires": {
+        "@types/node": "9.6.20",
+        "apollo-utilities": "1.0.13",
+        "zen-observable-ts": "0.8.9"
+      }
+    },
     "apollo-server-core": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-1.3.2.tgz",
@@ -866,6 +927,11 @@
       "requires": {
         "graphql-extensions": "0.0.7"
       }
+    },
+    "apollo-utilities": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.0.13.tgz",
+      "integrity": "sha512-WIbKDsFsLXMgPPGmlB2pL2noHT13TOLU2eRSyPjQMQwcz9lO9UKRkwK8pRJ8b4Zo/9qQHm30F/xlfP/OSr2ZSw=="
     },
     "append-transform": {
       "version": "0.4.0",
@@ -961,6 +1027,11 @@
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
+    },
+    "async": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
+      "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
     },
     "async-each": {
       "version": "1.0.1",
@@ -1357,6 +1428,14 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/base64id/-/base64id-1.0.0.tgz",
       "integrity": "sha1-R2iMuZu2gE8OBtPnY7HDLlfY5rY="
+    },
+    "basic-auth": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.0.tgz",
+      "integrity": "sha1-AV2z81PgLlY3d1X5YnQuiYHnu7o=",
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
     },
     "bcrypt-pbkdf": {
       "version": "1.0.1",
@@ -1795,6 +1874,11 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
+    "colors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+      "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
+    },
     "combined-stream": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
@@ -1977,6 +2061,11 @@
         "array-find-index": "1.0.2"
       }
     },
+    "cycle": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
+      "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI="
+    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -2097,6 +2186,11 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
       "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
+    },
+    "deprecated-decorator": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/deprecated-decorator/-/deprecated-decorator-0.1.6.tgz",
+      "integrity": "sha1-AJZjF7ehL+kvPMgx91g68ym4bDc="
     },
     "destroy": {
       "version": "1.0.4",
@@ -2529,6 +2623,11 @@
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
       "dev": true
+    },
+    "eyes": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+      "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A="
     },
     "fast-deep-equal": {
       "version": "1.1.0",
@@ -3735,6 +3834,55 @@
         "source-map-support": "0.5.3"
       }
     },
+    "graphql-fields": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/graphql-fields/-/graphql-fields-1.0.2.tgz",
+      "integrity": "sha1-CZ7h1ERbQtD0fgbWIqzrszq8bM4="
+    },
+    "graphql-middleware": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/graphql-middleware/-/graphql-middleware-1.2.6.tgz",
+      "integrity": "sha512-+agrI6GvkRx0jZTBAjzcmA49qE2B5y7RJBHolPO5EpZpBXSRw+vrHniXxfuXJyZo47uEsgTIfM2mTR9U2fKVvw==",
+      "requires": {
+        "graphql-tools": "3.0.2"
+      },
+      "dependencies": {
+        "graphql-tools": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/graphql-tools/-/graphql-tools-3.0.2.tgz",
+          "integrity": "sha512-bhDGrvmSgcJBFX3EZEYagmKPk/EJ9vZIcF1WtSFveWfvSsh7crMFSQ9ldftuIXC9UeRwfutpGf3A1q4UpVLaRg==",
+          "requires": {
+            "apollo-link": "1.2.1",
+            "apollo-utilities": "1.0.13",
+            "deprecated-decorator": "0.1.6",
+            "iterall": "1.1.3",
+            "uuid": "3.2.1"
+          }
+        }
+      }
+    },
+    "graphql-scalars": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/graphql-scalars/-/graphql-scalars-0.1.5.tgz",
+      "integrity": "sha1-+jHLas8XjB7TNfKthlOFvgNx5NY="
+    },
+    "graphql-tools": {
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/graphql-tools/-/graphql-tools-2.24.0.tgz",
+      "integrity": "sha512-Mz9I7jyizrd+RafC/5EogJKTVzBbIddDCrW0sP5QLmsVVM3ujfhqVYu2lEXOaJW8Sy18f3ZICHirmKcn6oMAcA==",
+      "requires": {
+        "apollo-link": "1.2.1",
+        "apollo-utilities": "1.0.13",
+        "deprecated-decorator": "0.1.6",
+        "iterall": "1.1.3",
+        "uuid": "3.2.1"
+      }
+    },
+    "graphql-type-json": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/graphql-type-json/-/graphql-type-json-0.1.4.tgz",
+      "integrity": "sha1-ifE/XTLOCMmnbHn9+cGWg4TYGk4="
+    },
     "growly": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
@@ -4367,8 +4515,7 @@
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-      "dev": true
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "istanbul-api": {
       "version": "1.3.1",
@@ -5178,8 +5325,7 @@
     "lodash": {
       "version": "4.17.5",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
-      "dev": true
+      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
     },
     "lodash.get": {
       "version": "4.4.2",
@@ -5445,6 +5591,18 @@
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         }
+      }
+    },
+    "morgan": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.9.0.tgz",
+      "integrity": "sha1-0B+mxlhZt2/PMbPLU6OCGjEdgFE=",
+      "requires": {
+        "basic-auth": "2.0.0",
+        "debug": "2.6.9",
+        "depd": "1.1.2",
+        "on-finished": "2.3.0",
+        "on-headers": "1.0.1"
       }
     },
     "ms": {
@@ -6051,6 +6209,11 @@
       "requires": {
         "ee-first": "1.1.1"
       }
+    },
+    "on-headers": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
+      "integrity": "sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c="
     },
     "once": {
       "version": "1.4.0",
@@ -7646,6 +7809,11 @@
         "tweetnacl": "0.14.5"
       }
     },
+    "stack-trace": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
+    },
     "stack-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.1.tgz",
@@ -8949,6 +9117,11 @@
         }
       }
     },
+    "utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
+      "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ=="
+    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -9095,6 +9268,19 @@
       "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
       "dev": true,
       "optional": true
+    },
+    "winston": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.2.tgz",
+      "integrity": "sha512-4S/Ad4ZfSNl8OccCLxnJmNISWcm2joa6Q0YGDxlxMzH0fgSwWsjMt+SmlNwCqdpaPg3ev1HKkMBsIiXeSUwpbA==",
+      "requires": {
+        "async": "1.0.0",
+        "colors": "1.0.3",
+        "cycle": "1.0.3",
+        "eyes": "0.1.8",
+        "isstream": "0.1.2",
+        "stack-trace": "0.0.10"
+      }
     },
     "wordwrap": {
       "version": "1.0.0",
@@ -9254,6 +9440,19 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
       "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk="
+    },
+    "zen-observable": {
+      "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.8.8.tgz",
+      "integrity": "sha512-HnhhyNnwTFzS48nihkCZIJGsWGFcYUz+XPDlPK5W84Ifji8SksC6m7sQWOf8zdCGhzQ4tDYuMYGu5B0N1dXTtg=="
+    },
+    "zen-observable-ts": {
+      "version": "0.8.9",
+      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.9.tgz",
+      "integrity": "sha512-KJz2O8FxbAdAU5CSc8qZ1K2WYEJb1HxS6XDRF+hOJ1rOYcg6eTMmS9xYHCXzqZZzKw6BbXWyF4UpwSsBQnHJeA==",
+      "requires": {
+        "zen-observable": "0.8.8"
+      }
     }
   }
 }

--- a/modules/server/package-lock.json
+++ b/modules/server/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@arranger/server",
-  "version": "0.3.48",
+  "version": "0.3.60",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
     "@arranger/mapping-utils": {
-      "version": "0.3.48",
-      "resolved": "https://registry.npmjs.org/@arranger/mapping-utils/-/mapping-utils-0.3.48.tgz",
-      "integrity": "sha512-L9Jo+VutboMZMGS2yF0f2BQswwD2QyE7on3OUF6PjGuqyBVKQK5UeVJoZQ1p90FVlHq7umPjeH0/hBN3mkU6Ag==",
+      "version": "0.3.60",
+      "resolved": "https://registry.npmjs.org/@arranger/mapping-utils/-/mapping-utils-0.3.60.tgz",
+      "integrity": "sha512-Te12XV3/ffLNE70bfvtCRf3sRaoSQwMb5cIV/xvI335BmYzG1MKOf/zX8T7kvDjNmVbLfW0gKRmciSAblNmUWw==",
       "requires": {
-        "@arranger/middleware": "0.3.48",
+        "@arranger/middleware": "0.3.60",
         "babel-polyfill": "6.26.0",
         "elasticsearch": "14.1.0",
         "graphql-fields": "1.0.2",
@@ -19,11 +19,10 @@
       }
     },
     "@arranger/middleware": {
-      "version": "0.3.48",
-      "resolved": "https://registry.npmjs.org/@arranger/middleware/-/middleware-0.3.48.tgz",
-      "integrity": "sha512-H4fq4ytY1kqtLJA3jNtOWj8xMrvcnXs+r9l1c6xVzu8Pf1IIuvg3yWKWNdPRZyr+yzh7KtrjyafxmIL9KBTCnw==",
+      "version": "0.3.60",
+      "resolved": "https://registry.npmjs.org/@arranger/middleware/-/middleware-0.3.60.tgz",
+      "integrity": "sha512-kt6gLT5QPnd6uBg1A28gQ5XHfYWZ4oiJNQfYYvUVZJhPQtF4HnQ+8nCojqb0hYFf8gL/utb9jkpyT9NTW/2H/A==",
       "requires": {
-        "@babel/plugin-proposal-export-namespace-from": "7.0.0-beta.47",
         "body-parser": "1.18.2",
         "cors": "2.8.4",
         "date-fns": "1.29.0",
@@ -35,14 +34,15 @@
       }
     },
     "@arranger/schema": {
-      "version": "0.3.48",
-      "resolved": "https://registry.npmjs.org/@arranger/schema/-/schema-0.3.48.tgz",
-      "integrity": "sha512-QUao/K15MGBDidEO95H6KO4OIiIjjqnpp7qNH9BSOtqO/Tj5IpbihnpXmVj0Mzv6kNfkqcfUi11FqR7gYIdHAg==",
+      "version": "0.3.60",
+      "resolved": "https://registry.npmjs.org/@arranger/schema/-/schema-0.3.60.tgz",
+      "integrity": "sha512-SkkHosh1oQOqWYbkabJ7ZBvEZtGJocM3elGcxNk0gXcVUCgdg4qux/QkiUB+mNZQJsTGrPI55BBHzOtHbhIW/w==",
       "requires": {
-        "@arranger/mapping-utils": "0.3.48",
-        "@arranger/middleware": "0.3.48",
+        "@arranger/mapping-utils": "0.3.60",
+        "@arranger/middleware": "0.3.60",
         "babel-polyfill": "6.26.0",
         "elasticsearch": "14.1.0",
+        "graphql-middleware": "1.2.6",
         "graphql-scalars": "0.1.5",
         "graphql-tools": "2.23.1",
         "graphql-type-json": "0.1.4",
@@ -345,22 +345,6 @@
         "@babel/plugin-syntax-async-generators": "7.0.0-beta.40"
       }
     },
-    "@babel/plugin-proposal-export-namespace-from": {
-      "version": "7.0.0-beta.47",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-namespace-from/-/plugin-proposal-export-namespace-from-7.0.0-beta.47.tgz",
-      "integrity": "sha512-tTYnPZzCrOm8NK+7lRi4LGxPaw6lErDsozNInM/FWOXGe7s2EpQnTa40S7/gLLNGvpNshYHdykJtKgfiar9qkA==",
-      "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.47",
-        "@babel/plugin-syntax-export-namespace-from": "7.0.0-beta.47"
-      },
-      "dependencies": {
-        "@babel/helper-plugin-utils": {
-          "version": "7.0.0-beta.47",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.47.tgz",
-          "integrity": "sha512-GR67o8boOKVJRKM5Nhk7oVEHpxYy8R00lwu0F82WxxBH+iiT26DqW1e/4w/mo7Bdn1A6l0pNaOlNk1PdM2Hgag=="
-        }
-      }
-    },
     "@babel/plugin-proposal-object-rest-spread": {
       "version": "7.0.0-beta.40",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.0.0-beta.40.tgz",
@@ -403,21 +387,6 @@
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-async-generators/-/plugin-syntax-async-generators-7.0.0-beta.40.tgz",
       "integrity": "sha512-UczObsgk1A4DaSMqTj59iETtmtuiXdBMs/1WBpy6LvLtf8AdjO/bZ2IbvrwKR5gEp8xJxBgzNq2sfK8RUsQBsQ==",
       "dev": true
-    },
-    "@babel/plugin-syntax-export-namespace-from": {
-      "version": "7.0.0-beta.47",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-export-namespace-from/-/plugin-syntax-export-namespace-from-7.0.0-beta.47.tgz",
-      "integrity": "sha512-mCNj425dtBdO95z1jMKoW0H3nZnTy9tjsdIuLw94uS+y97hvmFkFQtffqH+WIwEGxGBWq1Pn0OGfk3E8GfkhgQ==",
-      "requires": {
-        "@babel/helper-plugin-utils": "7.0.0-beta.47"
-      },
-      "dependencies": {
-        "@babel/helper-plugin-utils": {
-          "version": "7.0.0-beta.47",
-          "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.0.0-beta.47.tgz",
-          "integrity": "sha512-GR67o8boOKVJRKM5Nhk7oVEHpxYy8R00lwu0F82WxxBH+iiT26DqW1e/4w/mo7Bdn1A6l0pNaOlNk1PdM2Hgag=="
-        }
-      }
     },
     "@babel/plugin-syntax-object-rest-spread": {
       "version": "7.0.0-beta.40",
@@ -3869,6 +3838,28 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/graphql-fields/-/graphql-fields-1.0.2.tgz",
       "integrity": "sha1-CZ7h1ERbQtD0fgbWIqzrszq8bM4="
+    },
+    "graphql-middleware": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/graphql-middleware/-/graphql-middleware-1.2.6.tgz",
+      "integrity": "sha512-+agrI6GvkRx0jZTBAjzcmA49qE2B5y7RJBHolPO5EpZpBXSRw+vrHniXxfuXJyZo47uEsgTIfM2mTR9U2fKVvw==",
+      "requires": {
+        "graphql-tools": "3.0.2"
+      },
+      "dependencies": {
+        "graphql-tools": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/graphql-tools/-/graphql-tools-3.0.2.tgz",
+          "integrity": "sha512-bhDGrvmSgcJBFX3EZEYagmKPk/EJ9vZIcF1WtSFveWfvSsh7crMFSQ9ldftuIXC9UeRwfutpGf3A1q4UpVLaRg==",
+          "requires": {
+            "apollo-link": "1.2.1",
+            "apollo-utilities": "1.0.11",
+            "deprecated-decorator": "0.1.6",
+            "iterall": "1.1.3",
+            "uuid": "3.2.1"
+          }
+        }
+      }
     },
     "graphql-scalars": {
       "version": "0.1.5",

--- a/modules/server/package-lock.json
+++ b/modules/server/package-lock.json
@@ -1,55 +1,9 @@
 {
   "name": "@arranger/server",
-  "version": "0.3.60",
+  "version": "0.3.62",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@arranger/mapping-utils": {
-      "version": "0.3.60",
-      "resolved": "https://registry.npmjs.org/@arranger/mapping-utils/-/mapping-utils-0.3.60.tgz",
-      "integrity": "sha512-Te12XV3/ffLNE70bfvtCRf3sRaoSQwMb5cIV/xvI335BmYzG1MKOf/zX8T7kvDjNmVbLfW0gKRmciSAblNmUWw==",
-      "requires": {
-        "@arranger/middleware": "0.3.60",
-        "babel-polyfill": "6.26.0",
-        "elasticsearch": "14.1.0",
-        "graphql-fields": "1.0.2",
-        "lodash": "4.17.5",
-        "node-fetch": "2.0.0",
-        "uuid": "3.2.1"
-      }
-    },
-    "@arranger/middleware": {
-      "version": "0.3.60",
-      "resolved": "https://registry.npmjs.org/@arranger/middleware/-/middleware-0.3.60.tgz",
-      "integrity": "sha512-kt6gLT5QPnd6uBg1A28gQ5XHfYWZ4oiJNQfYYvUVZJhPQtF4HnQ+8nCojqb0hYFf8gL/utb9jkpyT9NTW/2H/A==",
-      "requires": {
-        "body-parser": "1.18.2",
-        "cors": "2.8.4",
-        "date-fns": "1.29.0",
-        "express": "4.16.2",
-        "lodash": "4.17.5",
-        "morgan": "1.9.0",
-        "utf8": "3.0.0",
-        "winston": "2.4.1"
-      }
-    },
-    "@arranger/schema": {
-      "version": "0.3.60",
-      "resolved": "https://registry.npmjs.org/@arranger/schema/-/schema-0.3.60.tgz",
-      "integrity": "sha512-SkkHosh1oQOqWYbkabJ7ZBvEZtGJocM3elGcxNk0gXcVUCgdg4qux/QkiUB+mNZQJsTGrPI55BBHzOtHbhIW/w==",
-      "requires": {
-        "@arranger/mapping-utils": "0.3.60",
-        "@arranger/middleware": "0.3.60",
-        "babel-polyfill": "6.26.0",
-        "elasticsearch": "14.1.0",
-        "graphql-middleware": "1.2.6",
-        "graphql-scalars": "0.1.5",
-        "graphql-tools": "2.23.1",
-        "graphql-type-json": "0.1.4",
-        "lodash": "4.17.5",
-        "uuid": "3.2.1"
-      }
-    },
     "@babel/cli": {
       "version": "7.0.0-beta.40",
       "resolved": "https://registry.npmjs.org/@babel/cli/-/cli-7.0.0-beta.40.tgz",
@@ -754,11 +708,6 @@
         "to-fast-properties": "2.0.0"
       }
     },
-    "@types/node": {
-      "version": "9.6.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.2.tgz",
-      "integrity": "sha512-UWkRY9X7RQHp5OhhRIIka58/gVVycL1zHZu0OTsT5LI86ABaMOSbUjAl+b0FeDhQcxclrkyft3kW5QWdMRs8wQ=="
-    },
     "JSONSelect": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/JSONSelect/-/JSONSelect-0.4.0.tgz",
@@ -886,16 +835,6 @@
         "graphql-extensions": "0.0.7"
       }
     },
-    "apollo-link": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/apollo-link/-/apollo-link-1.2.1.tgz",
-      "integrity": "sha512-6Ghf+j3cQLCIvjXd2dJrLw+16HZbWbwmB1qlTc41BviB2hv+rK1nJr17Y9dWK0UD4p3i9Hfddx3tthpMKrueHg==",
-      "requires": {
-        "@types/node": "9.6.2",
-        "apollo-utilities": "1.0.11",
-        "zen-observable-ts": "0.8.8"
-      }
-    },
     "apollo-server-core": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/apollo-server-core/-/apollo-server-core-1.3.2.tgz",
@@ -927,11 +866,6 @@
       "requires": {
         "graphql-extensions": "0.0.7"
       }
-    },
-    "apollo-utilities": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.0.11.tgz",
-      "integrity": "sha512-SAjRTqcYVHwpct+bcwX3x3zGEQOkNzj3Ri7Iy+vFIozxS8xtdkQqPiML7S6EI9Q2IuimQ7gvuYFHY0HQK0O1AA=="
     },
     "append-transform": {
       "version": "0.4.0",
@@ -1027,11 +961,6 @@
       "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
       "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
       "dev": true
-    },
-    "async": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
-      "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
     },
     "async-each": {
       "version": "1.0.1",
@@ -1428,14 +1357,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/base64id/-/base64id-1.0.0.tgz",
       "integrity": "sha1-R2iMuZu2gE8OBtPnY7HDLlfY5rY="
-    },
-    "basic-auth": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.0.tgz",
-      "integrity": "sha1-AV2z81PgLlY3d1X5YnQuiYHnu7o=",
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
     },
     "bcrypt-pbkdf": {
       "version": "1.0.1",
@@ -1874,11 +1795,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
-    "colors": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
-      "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
-    },
     "combined-stream": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
@@ -2061,11 +1977,6 @@
         "array-find-index": "1.0.2"
       }
     },
-    "cycle": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
-      "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI="
-    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -2186,11 +2097,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
       "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
-    },
-    "deprecated-decorator": {
-      "version": "0.1.6",
-      "resolved": "https://registry.npmjs.org/deprecated-decorator/-/deprecated-decorator-0.1.6.tgz",
-      "integrity": "sha1-AJZjF7ehL+kvPMgx91g68ym4bDc="
     },
     "destroy": {
       "version": "1.0.4",
@@ -2623,11 +2529,6 @@
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
       "dev": true
-    },
-    "eyes": {
-      "version": "0.1.8",
-      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
-      "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A="
     },
     "fast-deep-equal": {
       "version": "1.1.0",
@@ -3834,55 +3735,6 @@
         "source-map-support": "0.5.3"
       }
     },
-    "graphql-fields": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/graphql-fields/-/graphql-fields-1.0.2.tgz",
-      "integrity": "sha1-CZ7h1ERbQtD0fgbWIqzrszq8bM4="
-    },
-    "graphql-middleware": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/graphql-middleware/-/graphql-middleware-1.2.6.tgz",
-      "integrity": "sha512-+agrI6GvkRx0jZTBAjzcmA49qE2B5y7RJBHolPO5EpZpBXSRw+vrHniXxfuXJyZo47uEsgTIfM2mTR9U2fKVvw==",
-      "requires": {
-        "graphql-tools": "3.0.2"
-      },
-      "dependencies": {
-        "graphql-tools": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/graphql-tools/-/graphql-tools-3.0.2.tgz",
-          "integrity": "sha512-bhDGrvmSgcJBFX3EZEYagmKPk/EJ9vZIcF1WtSFveWfvSsh7crMFSQ9ldftuIXC9UeRwfutpGf3A1q4UpVLaRg==",
-          "requires": {
-            "apollo-link": "1.2.1",
-            "apollo-utilities": "1.0.11",
-            "deprecated-decorator": "0.1.6",
-            "iterall": "1.1.3",
-            "uuid": "3.2.1"
-          }
-        }
-      }
-    },
-    "graphql-scalars": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/graphql-scalars/-/graphql-scalars-0.1.5.tgz",
-      "integrity": "sha1-+jHLas8XjB7TNfKthlOFvgNx5NY="
-    },
-    "graphql-tools": {
-      "version": "2.23.1",
-      "resolved": "https://registry.npmjs.org/graphql-tools/-/graphql-tools-2.23.1.tgz",
-      "integrity": "sha512-f85OdRuPcHvMhNqiotvgtzpx7RlY2pZW9UnmBu6AcooKVipWVyy0um9q17f78BBI+1UzwAMsfU9S6R38UGMjTQ==",
-      "requires": {
-        "apollo-link": "1.2.1",
-        "apollo-utilities": "1.0.11",
-        "deprecated-decorator": "0.1.6",
-        "iterall": "1.1.3",
-        "uuid": "3.2.1"
-      }
-    },
-    "graphql-type-json": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/graphql-type-json/-/graphql-type-json-0.1.4.tgz",
-      "integrity": "sha1-ifE/XTLOCMmnbHn9+cGWg4TYGk4="
-    },
     "growly": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
@@ -4515,7 +4367,8 @@
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
     },
     "istanbul-api": {
       "version": "1.3.1",
@@ -5325,7 +5178,8 @@
     "lodash": {
       "version": "4.17.5",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
+      "dev": true
     },
     "lodash.get": {
       "version": "4.4.2",
@@ -5591,18 +5445,6 @@
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
           "dev": true
         }
-      }
-    },
-    "morgan": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.9.0.tgz",
-      "integrity": "sha1-0B+mxlhZt2/PMbPLU6OCGjEdgFE=",
-      "requires": {
-        "basic-auth": "2.0.0",
-        "debug": "2.6.9",
-        "depd": "1.1.2",
-        "on-finished": "2.3.0",
-        "on-headers": "1.0.1"
       }
     },
     "ms": {
@@ -6209,11 +6051,6 @@
       "requires": {
         "ee-first": "1.1.1"
       }
-    },
-    "on-headers": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/on-headers/-/on-headers-1.0.1.tgz",
-      "integrity": "sha1-ko9dD0cNSTQmUepnlLCFfBAGk/c="
     },
     "once": {
       "version": "1.4.0",
@@ -7809,11 +7646,6 @@
         "tweetnacl": "0.14.5"
       }
     },
-    "stack-trace": {
-      "version": "0.0.10",
-      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
-      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
-    },
     "stack-utils": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/stack-utils/-/stack-utils-1.0.1.tgz",
@@ -9117,11 +8949,6 @@
         }
       }
     },
-    "utf8": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
-      "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ=="
-    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
@@ -9268,19 +9095,6 @@
       "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
       "dev": true,
       "optional": true
-    },
-    "winston": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.1.tgz",
-      "integrity": "sha512-k/+Dkzd39ZdyJHYkuaYmf4ff+7j+sCIy73UCOWHYA67/WXU+FF/Y6PF28j+Vy7qNRPHWO+dR+/+zkoQWPimPqg==",
-      "requires": {
-        "async": "1.0.0",
-        "colors": "1.0.3",
-        "cycle": "1.0.3",
-        "eyes": "0.1.8",
-        "isstream": "0.1.2",
-        "stack-trace": "0.0.10"
-      }
     },
     "wordwrap": {
       "version": "1.0.0",
@@ -9440,19 +9254,6 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
       "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk="
-    },
-    "zen-observable": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.7.1.tgz",
-      "integrity": "sha512-OI6VMSe0yeqaouIXtedC+F55Sr6r9ppS7+wTbSexkYdHbdt4ctTuPNXP/rwm7GTVI63YBc+EBT0b0tl7YnJLRg=="
-    },
-    "zen-observable-ts": {
-      "version": "0.8.8",
-      "resolved": "https://registry.npmjs.org/zen-observable-ts/-/zen-observable-ts-0.8.8.tgz",
-      "integrity": "sha512-oGjFvBbAA94uh/HvAwJDwMHtNq4lZRtupJx8XsyreOTYvH8x1ef9hIeH/M+IqiAXtNpglq/Klh5rbpYWEeRSOQ==",
-      "requires": {
-        "zen-observable": "0.7.1"
-      }
     }
   }
 }

--- a/modules/server/package.json
+++ b/modules/server/package.json
@@ -35,6 +35,7 @@
     "chalk": "^2.3.1",
     "chalk-animation": "^1.3.0",
     "cors": "^2.8.4",
+    "date-fns": "^1.29.0",
     "dotenv": "^5.0.0",
     "elasticsearch": "^14.0.0",
     "express": "^4.16.2",

--- a/modules/server/package.json
+++ b/modules/server/package.json
@@ -40,6 +40,7 @@
     "express": "^4.16.2",
     "graphql": "^0.11.0",
     "jsonpath": "^1.0.0",
+    "multer": "^1.3.0",
     "node-fetch": "^2.0.0",
     "socket.io": "^2.0.4",
     "socket.io-stream": "^0.9.1",

--- a/modules/server/package.json
+++ b/modules/server/package.json
@@ -40,7 +40,6 @@
     "express": "^4.16.2",
     "graphql": "^0.11.0",
     "jsonpath": "^1.0.0",
-    "multer": "^1.3.0",
     "node-fetch": "^2.0.0",
     "socket.io": "^2.0.4",
     "socket.io-stream": "^0.9.1",

--- a/modules/server/src/projects/addType.js
+++ b/modules/server/src/projects/addType.js
@@ -1,13 +1,13 @@
-import { flattenDeep } from 'lodash';
 import { extendMapping } from '@arranger/mapping-utils';
 import { fetchMappings } from '../utils/fetchMappings';
 import mapHits from '../utils/mapHits';
 import getIndexPrefix from '../utils/getIndexPrefix';
+import initializeExtendedFields from '../utils/initializeExtendedFields';
 
 export default async (req, res) => {
   let { es } = req.context;
   let { id } = req.params;
-  let { index, name } = req.body;
+  let { index, name, config: rawConfig = {} } = req.body;
 
   const esType =
     req.body.esType && req.body.esType.length ? req.body.esType : index;
@@ -20,12 +20,21 @@ export default async (req, res) => {
   id = id.toLowerCase();
   index = index.toLowerCase();
 
+  const indexPrefix = getIndexPrefix({ projectId: id, index });
   let arrangerConfig = {
     projectsIndex: {
       index: `arranger-projects-${id}`,
       type: `arranger-projects-${id}`,
     },
   };
+
+  const config = rawConfig.reduce(
+    (obj, c) => ({
+      ...obj,
+      [c.name.replace('.json', '')]: c.content,
+    }),
+    {},
+  );
 
   try {
     await es.create({
@@ -36,6 +45,7 @@ export default async (req, res) => {
         index,
         name,
         esType,
+        config,
         active: true,
         timestamp: new Date().toISOString(),
       },
@@ -64,7 +74,6 @@ export default async (req, res) => {
   let mappings = await fetchMappings({ es, types: hits });
 
   if (hits.some(x => mappings.find(y => y.index === x.index).mapping)) {
-    const indexPrefix = getIndexPrefix({ projectId: id, index });
     try {
       await es.indices.create({
         index: indexPrefix,
@@ -82,21 +91,9 @@ export default async (req, res) => {
 
       let fields = extendMapping(mapping);
 
-      let body = flattenDeep(
-        fields.map(x => [
-          {
-            index: {
-              _index: indexPrefix,
-              _type: indexPrefix,
-              _id: x.field,
-            },
-          },
-          JSON.stringify(x),
-        ]),
-      );
-
-      await es.bulk({ body });
+      await initializeExtendedFields({ indexPrefix, config, fields, es });
     } catch (error) {
+      console.log(error);
       return res.json({ error: error.message });
     }
   }

--- a/modules/server/src/projects/addType.js
+++ b/modules/server/src/projects/addType.js
@@ -93,7 +93,7 @@ export default async (req, res) => {
 
       await initializeExtendedFields({ indexPrefix, config, fields, es });
     } catch (error) {
-      console.log(error);
+      console.error(error);
       return res.json({ error: error.message });
     }
   }

--- a/modules/server/src/projects/export.js
+++ b/modules/server/src/projects/export.js
@@ -2,6 +2,9 @@ import { groupBy } from 'lodash';
 import zlib from 'zlib';
 import tar from 'tar-stream';
 
+import getTypes from '../utils/getTypes';
+import mapHits from '../utils/mapHits';
+
 const getAllResults = async ({ es, search, results = [] }) => {
   const response = await es.search(search);
   const nextResults = [...results, ...response.hits.hits];
@@ -17,38 +20,57 @@ const getAllResults = async ({ es, search, results = [] }) => {
     : nextResults;
 };
 
+const jamTypeStateInPack = async ({ type, pack, id, es }) => {
+  const indexPrefix = `arranger-projects-${id}`;
+  const fileName = ({ key, typeKey = key.replace(`${indexPrefix}-`, '') }) =>
+    typeKey === type ? `extended` : typeKey.replace(`${type}-`, '');
+
+  let results;
+  try {
+    results = groupBy(
+      await getAllResults({
+        es,
+        search: {
+          index: `${indexPrefix}-${type}*`,
+          size: 500,
+          sort: ['_index:asc', '_id:asc'],
+        },
+      }),
+      '_index',
+    );
+  } catch (err) {
+    results = {};
+  }
+
+  await Promise.all(
+    Object.keys(results).map(
+      key =>
+        new Promise((res, rej) =>
+          pack.entry(
+            {
+              name: `arranger-project-${id}/${type}/${fileName({
+                key,
+              })}.json`,
+            },
+            JSON.stringify(results[key], null, 2),
+            err => (err ? rej(err) : res()),
+          ),
+        ),
+    ),
+  );
+};
+
 export default async (req, res) => {
   let { es } = req.context;
   let { id } = req.params;
 
   if (!id) return res.json({ error: 'project empty' });
 
-  id = id.toLowerCase();
-
-  const results = groupBy(
-    await getAllResults({
-      es,
-      search: {
-        index: `arranger-projects-${id}*`,
-        size: 500,
-        sort: ['_index:asc', '_id:asc'],
-      },
-    }),
-    '_index',
-  );
+  const types = mapHits(await getTypes({ id, es })).map(x => x.index);
 
   const pack = tar.pack();
   await Promise.all(
-    Object.keys(results).map(
-      k =>
-        new Promise((res, rej) =>
-          pack.entry(
-            { name: `${k}.json` },
-            JSON.stringify(results[k], null, 2),
-            err => (err ? rej(err) : res()),
-          ),
-        ),
-    ),
+    types.map(type => jamTypeStateInPack({ type, pack, id, es })),
   );
   await pack.finalize();
 

--- a/modules/server/src/projects/export.js
+++ b/modules/server/src/projects/export.js
@@ -1,3 +1,4 @@
+import { parse } from 'date-fns';
 import { groupBy, mapKeys } from 'lodash';
 import zlib from 'zlib';
 import tar from 'tar-stream';
@@ -25,7 +26,8 @@ const mapState = (key, state) => {
   if (key === 'extended') {
     return source;
   } else if (['aggs-state', 'columns-state', 'matchbox-state'].includes(key)) {
-    return source[0].state;
+    return source.sort((x, y) => parse(y.timestamp) - parse(x.timestamp))[0]
+      .state;
   } else {
     console.log(
       `[export] - WARNING - no import strategy for config state '${key}'`,

--- a/modules/server/src/projects/export.js
+++ b/modules/server/src/projects/export.js
@@ -1,5 +1,21 @@
-import express from 'express';
-import { setProject, getProject } from '../utils/projects';
+import { groupBy } from 'lodash';
+import zlib from 'zlib';
+import tar from 'tar-stream';
+
+const getAllResults = async ({ es, search, results = [] }) => {
+  const response = await es.search(search);
+  const nextResults = [...results, ...response.hits.hits];
+  return nextResults.length < response.hits.total
+    ? await getAllResults({
+        es,
+        search: {
+          ...search,
+          body: { search_after: nextResults.slice(-1)[0].sort },
+        },
+        results: nextResults,
+      })
+    : nextResults;
+};
 
 export default async (req, res) => {
   let { es } = req.context;
@@ -9,11 +25,33 @@ export default async (req, res) => {
 
   id = id.toLowerCase();
 
-  console.log(id);
+  const results = groupBy(
+    await getAllResults({
+      es,
+      search: {
+        index: `arranger-projects-${id}*`,
+        size: 500,
+        sort: ['_index:asc', '_id:asc'],
+      },
+    }),
+    '_index',
+  );
 
-  // es.search({
-  //   index: ''
-  // })
+  const pack = tar.pack();
+  await Promise.all(
+    Object.keys(results).map(
+      k =>
+        new Promise((res, rej) =>
+          pack.entry(
+            { name: `${k}.json` },
+            JSON.stringify(results[k], null, 2),
+            err => (err ? rej(err) : res()),
+          ),
+        ),
+    ),
+  );
+  await pack.finalize();
 
-  res.json({ message: `hi jordan` });
+  res.attachment(`arranger-project-${id}.tar.gz`);
+  pack.pipe(zlib.createGzip()).pipe(res);
 };

--- a/modules/server/src/projects/export.js
+++ b/modules/server/src/projects/export.js
@@ -1,0 +1,19 @@
+import express from 'express';
+import { setProject, getProject } from '../utils/projects';
+
+export default async (req, res) => {
+  let { es } = req.context;
+  let { id } = req.params;
+
+  if (!id) return res.json({ error: 'project empty' });
+
+  id = id.toLowerCase();
+
+  console.log(id);
+
+  // es.search({
+  //   index: ''
+  // })
+
+  res.json({ message: `hi jordan` });
+};

--- a/modules/server/src/projects/getFields.js
+++ b/modules/server/src/projects/getFields.js
@@ -1,7 +1,11 @@
 import { flattenDeep } from 'lodash';
+
 import { extendFields, extendMapping } from '@arranger/mapping-utils';
+
 import mapHits from '../utils/mapHits';
 import getIndexPrefix from '../utils/getIndexPrefix';
+import initializeExtendedFields from '../utils/initializeExtendedFields';
+import { fetchMapping } from '../utils/fetchMappings';
 
 export default async (req, res) => {
   let { es } = req.context;
@@ -47,39 +51,30 @@ export default async (req, res) => {
       const projectInfo = await es.search({
         index: projectInfoIndex,
         type: projectInfoIndex,
-        size: 0,
-        _source: false,
       });
-      const esType = projectInfo?.hits?.hits?._source?.esType;
+      const { esType, config } =
+        projectInfo?.hits?.hits?.find(x => x._id === index)?._source || {};
 
       let aliases = await es.cat.aliases({ format: 'json' });
       let alias = aliases?.find(x => x.alias === index)?.index;
 
-      let mappings = await es.indices.getMapping({
+      const response = await fetchMapping({
         index: alias || index,
-        type: esType,
+        esType,
+        es,
+      });
+      let mappingFields = response ? extendMapping(response.mapping) : [];
+
+      const fields = await initializeExtendedFields({
+        indexPrefix,
+        fields: mappingFields,
+        config,
+        es,
       });
 
-      let mapping = mappings[alias || index].mappings[esType].properties;
-
-      let fields = extendMapping(mapping);
-
-      let body = flattenDeep(
-        fields.map(x => [
-          {
-            index: {
-              _index: arrangerConfig.projectsIndex.index,
-              _type: arrangerConfig.projectsIndex.index,
-              _id: x.field,
-            },
-          },
-          JSON.stringify(x),
-        ]),
-      );
-
-      await es.bulk({ body });
       return res.json({ fields, total: fields.length });
     } catch (error) {
+      console.error(error);
       return res.json({ error: error.message });
     }
   }

--- a/modules/server/src/projects/index.js
+++ b/modules/server/src/projects/index.js
@@ -5,6 +5,7 @@ import getFields from './getFields';
 import addType from './addType';
 import spinUp from './spinUp';
 import teardown from './teardown';
+import exportProject from './export';
 import getTypes from './getTypes';
 import updateProject from './updateProject';
 import deleteProject from './deleteProject';
@@ -38,6 +39,7 @@ export default ({ io, graphqlOptions }) => {
   router.use('/:id/types/add', addType);
   router.use('/:id/spinUp', spinUp({ io, graphqlOptions }));
   router.use('/:id/teardown', teardown);
+  router.use('/:id/export', exportProject);
   router.use('/:id/types', getTypes);
   router.use('/:id/delete', deleteProject);
   router.use('/:id/update', updateProject);

--- a/modules/server/src/projects/index.js
+++ b/modules/server/src/projects/index.js
@@ -1,5 +1,6 @@
 import elasticsearch from 'elasticsearch';
 import express from 'express';
+
 import { ES_LOG } from '../utils/config';
 import getFields from './getFields';
 import addType from './addType';

--- a/modules/server/src/server.js
+++ b/modules/server/src/server.js
@@ -24,6 +24,7 @@ export default async ({
   graphqlOptions = {},
 } = {}) => {
   const router = express.Router();
+  router.use(bodyParser.urlencoded({ extended: false }));
   router.use(bodyParser.json({ limit: '50mb' }));
 
   sockets({ io });

--- a/modules/server/src/startProject.js
+++ b/modules/server/src/startProject.js
@@ -35,6 +35,15 @@ const initializeSets = async ({ es }) => {
   }
 };
 
+const mergeFieldsFromConfig = (generatedFields, configFields) => {
+  const a = generatedFields || [];
+  const b = configFields || [];
+  return [
+    ...b.filter(x => a.find(y => y.field === x.field)),
+    ...a.filter(x => !b.find(y => y.field === x.field)),
+  ];
+};
+
 export default async function startProjectApp({
   es,
   id,
@@ -114,10 +123,9 @@ export default async function startProjectApp({
           { index: { _index: index, _type: index, _id: uuid() } },
           JSON.stringify({
             timestamp: new Date().toISOString(),
-            state: replaceBy(
+            state: mergeFieldsFromConfig(
               mappingToAggsState(props.mapping),
               props.config['aggs-state'],
-              (x, y) => x.field === y.field,
             ),
           }),
         ]
@@ -160,10 +168,9 @@ export default async function startProjectApp({
               ],
               ...(get(existing, 'state') || {}),
               ...(props.config['columns-state'] || {}),
-              columns: replaceBy(
+              columns: mergeFieldsFromConfig(
                 [...existingColumns, ...newColumns],
                 props.config['columns-state']?.columns,
-                (x, y) => x.field === y.field,
               ),
             },
           }),

--- a/modules/server/src/startProject.js
+++ b/modules/server/src/startProject.js
@@ -17,17 +17,7 @@ import download from './download';
 import getIndexPrefix from './utils/getIndexPrefix';
 import { setsMapping } from '@arranger/schema';
 import { CONSTANTS } from '@arranger/middleware';
-
-async function getTypes({ id, es }) {
-  const index = `arranger-projects-${id}`;
-
-  try {
-    return await es.search({ index, type: index });
-  } catch (error) {
-    await es.indices.create({ index });
-    return null;
-  }
-}
+import getTypes from './utils/getTypes';
 
 const initializeSets = async ({ es }) => {
   if (!await es.indices.exists({ index: CONSTANTS.ES_ARRANGER_SET_INDEX })) {

--- a/modules/server/src/utils/getTypes.js
+++ b/modules/server/src/utils/getTypes.js
@@ -1,0 +1,12 @@
+const getTypes = async ({ id, es }) => {
+  const index = `arranger-projects-${id}`;
+
+  try {
+    return await es.search({ index, type: index });
+  } catch (error) {
+    await es.indices.create({ index });
+    return null;
+  }
+};
+
+export default getTypes;

--- a/modules/server/src/utils/initializeExtendedFields.js
+++ b/modules/server/src/utils/initializeExtendedFields.js
@@ -1,0 +1,33 @@
+import { flattenDeep } from 'lodash';
+
+import replaceBy from './replaceBy';
+
+const initializeExtendedFields = async ({
+  indexPrefix,
+  fields,
+  config,
+  es,
+}) => {
+  const mergedFields = fields?.length
+    ? replaceBy(fields, config.extended, (x, y) => x.field === y.field)
+    : config.extended;
+
+  let body = flattenDeep(
+    mergedFields.map(f => [
+      {
+        index: {
+          _index: indexPrefix,
+          _type: indexPrefix,
+          _id: f.field,
+        },
+      },
+      JSON.stringify(f),
+    ]),
+  );
+
+  await es.bulk({ body });
+
+  return mergedFields;
+};
+
+export default initializeExtendedFields;

--- a/modules/server/src/utils/replaceBy.js
+++ b/modules/server/src/utils/replaceBy.js
@@ -1,0 +1,5 @@
+export default (arr1, arr2, operator) => {
+  const cArr1 = arr1 || [];
+  const cArr2 = arr2 || [];
+  return cArr1.map(x => cArr2.find(y => operator(x, y)) || x);
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1557,6 +1557,22 @@
         }
       }
     },
+    "@babel/runtime": {
+      "version": "7.0.0-beta.49",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.0.0-beta.49.tgz",
+      "integrity": "sha1-A7O/B+uYIHLI6FHdLd1RECguYb8=",
+      "requires": {
+        "core-js": "2.5.7",
+        "regenerator-runtime": "0.11.1"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "2.5.7",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
+          "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
+        }
+      }
+    },
     "@babel/template": {
       "version": "7.0.0-beta.36",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.36.tgz",
@@ -2211,6 +2227,11 @@
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/apollo-utilities/-/apollo-utilities-1.0.12.tgz",
       "integrity": "sha512-3mSen+NLouRwhmzCSHbMICfLBa6J+QJOc+M8zzLyo10jAYsOK+A2VgR63q4mcQJmAp8LumC5VAyah1zw6enMcg=="
+    },
+    "append-field": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-0.1.0.tgz",
+      "integrity": "sha1-bdxY+gg8e8VF08WZWygwzCNm1Eo="
     },
     "append-transform": {
       "version": "0.4.0",
@@ -4368,6 +4389,38 @@
       "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
       "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug="
     },
+    "busboy": {
+      "version": "0.2.14",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-0.2.14.tgz",
+      "integrity": "sha1-bCpiLvz0fFe7vh4qnDetNseSVFM=",
+      "requires": {
+        "dicer": "0.2.5",
+        "readable-stream": "1.1.14"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        }
+      }
+    },
     "byline": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/byline/-/byline-5.0.0.tgz",
@@ -6249,6 +6302,38 @@
         }
       }
     },
+    "dicer": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.2.5.tgz",
+      "integrity": "sha1-WZbAhrszIYyBLAkL3cCc0S+stw8=",
+      "requires": {
+        "readable-stream": "1.1.14",
+        "streamsearch": "0.1.2"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+        },
+        "readable-stream": {
+          "version": "1.1.14",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "requires": {
+            "core-util-is": "1.0.2",
+            "inherits": "2.0.3",
+            "isarray": "0.0.1",
+            "string_decoder": "0.10.31"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+        }
+      }
+    },
     "diff": {
       "version": "3.5.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
@@ -7654,8 +7739,7 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ansi-regex": {
           "version": "2.1.1",
@@ -7663,13 +7747,11 @@
         },
         "aproba": {
           "version": "1.2.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "are-we-there-yet": {
           "version": "1.1.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "delegates": "1.0.0",
             "readable-stream": "2.3.6"
@@ -7689,8 +7771,7 @@
         },
         "chownr": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "code-point-at": {
           "version": "1.1.0",
@@ -7706,31 +7787,26 @@
         },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "debug": {
           "version": "2.6.9",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ms": "2.0.0"
           }
         },
         "deep-extend": {
           "version": "0.5.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "delegates": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "fs-minipass": {
           "version": "1.2.5",
@@ -7741,13 +7817,11 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "gauge": {
           "version": "2.7.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "aproba": "1.2.0",
             "console-control-strings": "1.1.0",
@@ -7773,13 +7847,11 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "iconv-lite": {
           "version": "0.4.21",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safer-buffer": "2.1.2"
           }
@@ -7787,7 +7859,6 @@
         "ignore-walk": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimatch": "3.0.4"
           }
@@ -7806,8 +7877,7 @@
         },
         "ini": {
           "version": "1.3.5",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
@@ -7818,8 +7888,7 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minimatch": {
           "version": "3.0.4",
@@ -7856,13 +7925,11 @@
         },
         "ms": {
           "version": "2.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "needle": {
           "version": "2.2.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "debug": "2.6.9",
             "iconv-lite": "0.4.21",
@@ -7888,7 +7955,6 @@
         "nopt": {
           "version": "4.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "abbrev": "1.1.1",
             "osenv": "0.1.5"
@@ -7896,13 +7962,11 @@
         },
         "npm-bundled": {
           "version": "1.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "npm-packlist": {
           "version": "1.1.10",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ignore-walk": "3.0.1",
             "npm-bundled": "1.0.3"
@@ -7911,7 +7975,6 @@
         "npmlog": {
           "version": "4.1.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "are-we-there-yet": "1.1.4",
             "console-control-strings": "1.1.0",
@@ -7925,8 +7988,7 @@
         },
         "object-assign": {
           "version": "4.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "once": {
           "version": "1.4.0",
@@ -7937,18 +7999,15 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "osenv": {
           "version": "0.1.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "os-homedir": "1.0.2",
             "os-tmpdir": "1.0.2"
@@ -7956,18 +8015,15 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "rc": {
           "version": "1.2.7",
           "bundled": true,
-          "optional": true,
           "requires": {
             "deep-extend": "0.5.1",
             "ini": "1.3.5",
@@ -7977,15 +8033,13 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "bundled": true,
-              "optional": true
+              "bundled": true
             }
           }
         },
         "readable-stream": {
           "version": "2.3.6",
           "bundled": true,
-          "optional": true,
           "requires": {
             "core-util-is": "1.0.2",
             "inherits": "2.0.3",
@@ -8009,28 +8063,23 @@
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "sax": {
           "version": "1.2.4",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "semver": {
           "version": "5.5.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "string-width": {
           "version": "1.0.2",
@@ -8044,7 +8093,6 @@
         "string_decoder": {
           "version": "1.1.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "5.1.1"
           }
@@ -8058,8 +8106,7 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "tar": {
           "version": "4.4.1",
@@ -8076,13 +8123,11 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "wide-align": {
           "version": "1.1.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "string-width": "1.0.2"
           }
@@ -11492,6 +11537,28 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+    },
+    "multer": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-1.3.0.tgz",
+      "integrity": "sha1-CSsmcPaEb6SRSWXvyM+Uwg/sbNI=",
+      "requires": {
+        "append-field": "0.1.0",
+        "busboy": "0.2.14",
+        "concat-stream": "1.6.0",
+        "mkdirp": "0.5.1",
+        "object-assign": "3.0.0",
+        "on-finished": "2.3.0",
+        "type-is": "1.6.16",
+        "xtend": "4.0.1"
+      },
+      "dependencies": {
+        "object-assign": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+          "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I="
+        }
+      }
     },
     "mute-stream": {
       "version": "0.0.7",
@@ -15052,6 +15119,17 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-4.0.0.tgz",
       "integrity": "sha512-FlsPxavEyMuR6TjVbSSywovXSEyOg6ZDj5+Z8nbsRl9EkOzAhEIcS+GLoQDC5fz/t9suhUXWmUrOBrgeUvrMxw=="
     },
+    "react-event-listener": {
+      "version": "0.5.9",
+      "resolved": "https://registry.npmjs.org/react-event-listener/-/react-event-listener-0.5.9.tgz",
+      "integrity": "sha1-xk6E93FWpoJhSDW9wbx7oAkS35c=",
+      "requires": {
+        "@babel/runtime": "7.0.0-beta.49",
+        "fbjs": "0.8.16",
+        "prop-types": "15.6.0",
+        "warning": "3.0.0"
+      }
+    },
     "react-fuzzy": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/react-fuzzy/-/react-fuzzy-0.5.2.tgz",
@@ -15210,6 +15288,17 @@
         "prop-types": "15.6.0",
         "react-router": "4.2.0",
         "warning": "3.0.0"
+      }
+    },
+    "react-scrollbar-size": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/react-scrollbar-size/-/react-scrollbar-size-2.1.0.tgz",
+      "integrity": "sha512-9dDUJvk7S48r0TRKjlKJ9e/LkLLYgc9LdQR6W21I8ZqtSrEsedPOoMji4nU3DHy7fx2l8YMScJS/N7qiloYzXQ==",
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "prop-types": "15.6.0",
+        "react-event-listener": "0.5.9",
+        "stifle": "1.0.4"
       }
     },
     "react-spinkit": {
@@ -16804,6 +16893,11 @@
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
       "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
     },
+    "stifle": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/stifle/-/stifle-1.0.4.tgz",
+      "integrity": "sha1-izvN9SQZsKnHnjWtrc5QEjwdjpk="
+    },
     "storybook-router": {
       "version": "0.3.4",
       "resolved": "https://registry.npmjs.org/storybook-router/-/storybook-router-0.3.4.tgz",
@@ -16897,6 +16991,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
       "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI="
+    },
+    "streamsearch": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
+      "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo="
     },
     "strict-uri-encode": {
       "version": "1.1.0",


### PR DESCRIPTION
Adds the ability to export (download) an arranger project config, and import (upload) config when adding a type.

Export comes in a tarball, with one subdir per type. Each type includes the `extended`, `aggs-state`, `columns-state`, and `matchbox-state` json config files.

When adding a type you can optionally upload config files, which are stored with the type in the arranger version meta. The spinup flow hasn't changed - extended fields are initialized in `addType`, the other states are initialized on spinup.

Import treats the generated mapping as the source of truth, and just overwrites fields that have a config found in one of the uploaded config files, if they exist.