### PR TITLE
🐛 Aggregations on nested fields are not scoped properly

### DIFF
--- a/modules/mapping-utils/src/resolveAggregations.js
+++ b/modules/mapping-utils/src/resolveAggregations.js
@@ -29,6 +29,7 @@ export default type => async (
 
   const query = buildQuery({ nestedFields, filters: resolvedFilter });
   const aggs = buildAggregations({
+    query,
     sqon: resolvedFilter,
     graphqlFields: getFields(info),
     nestedFields,

--- a/modules/mapping-utils/src/resolveAggregations.js
+++ b/modules/mapping-utils/src/resolveAggregations.js
@@ -29,7 +29,7 @@ export default type => async (
 
   const query = buildQuery({ nestedFields, filters: resolvedFilter });
   const aggs = buildAggregations({
-    query,
+    sqon: resolvedFilter,
     graphqlFields: getFields(info),
     nestedFields,
     aggregationsFilterThemselves: aggregations_filter_themselves,

--- a/modules/middleware/src/buildAggregations.js
+++ b/modules/middleware/src/buildAggregations.js
@@ -1,5 +1,5 @@
 import { get, isEqual } from 'lodash';
-
+import buildQuery from './buildQuery';
 import {
   AGGS_WRAPPER_GLOBAL,
   AGGS_WRAPPER_FILTERED,
@@ -129,11 +129,12 @@ function wrapWithFilters({
 }
 
 export default function({
+  sqon,
   graphqlFields,
   nestedFields,
-  query,
   aggregationsFilterThemselves,
 }) {
+  const query = buildQuery({ nestedFields, filters: sqon });
   return Object.entries(graphqlFields).reduce(
     (aggregations, [fieldKey, graphqlField]) => {
       const field = fieldKey.replace(/__/g, '.');

--- a/modules/middleware/src/buildAggregations.js
+++ b/modules/middleware/src/buildAggregations.js
@@ -129,6 +129,11 @@ function wrapWithFilters({
   return aggregation;
 }
 
+/*
+ * due to this problem: https://github.com/kids-first/kf-portal-ui/issues/488
+ * queries that are on a term that shares a parent with a aggregation field
+ * needs to be dropped down to the aggregation level as a filter.
+ */
 export const injectNestedFiltersToAggs = ({
   aggs,
   nestedSqonFilters,

--- a/modules/middleware/src/buildAggregations.js
+++ b/modules/middleware/src/buildAggregations.js
@@ -201,8 +201,8 @@ export default function({
   graphqlFields,
   nestedFields,
   aggregationsFilterThemselves,
+  query,
 }) {
-  const query = buildQuery({ nestedFields, filters: sqon });
   const nestedSqonFilters = (sqon?.content || [])
     .filter(({ content }) => {
       const splitted = content.field.split('.');

--- a/modules/middleware/src/buildAggregations.js
+++ b/modules/middleware/src/buildAggregations.js
@@ -1,5 +1,5 @@
 import { get, isEqual } from 'lodash';
-import buildQuery, { opSwitch } from './buildQuery';
+import { opSwitch } from './buildQuery';
 import normalizeFilters from './buildQuery/normalizeFilters';
 import {
   AGGS_WRAPPER_GLOBAL,

--- a/modules/middleware/src/buildAggregations.js
+++ b/modules/middleware/src/buildAggregations.js
@@ -136,7 +136,19 @@ const injectNestedFiltersToAggs = ({
   aggregationsFilterThemselves,
 }) => {
   return Object.entries(aggs).reduce((acc, [aggName, aggContent]) => {
-    if (aggContent.nested) {
+    if (aggContent.global || aggContent.filter) {
+      return {
+        ...acc,
+        [aggName]: {
+          ...aggContent,
+          aggs: injectNestedFiltersToAggs({
+            aggs: aggContent.aggs,
+            nestedSqonFilters,
+            aggregationsFilterThemselves,
+          }),
+        },
+      };
+    } else if (aggContent.nested) {
       if (nestedSqonFilters[aggContent.nested.path]) {
         return {
           ...acc,

--- a/modules/middleware/src/buildAggregations.js
+++ b/modules/middleware/src/buildAggregations.js
@@ -1,7 +1,6 @@
 import { get, isEqual } from 'lodash';
 import buildQuery, { opSwitch } from './buildQuery';
 import normalizeFilters from './buildQuery/normalizeFilters';
-import { cloneDeep } from 'lodash';
 import {
   AGGS_WRAPPER_GLOBAL,
   AGGS_WRAPPER_FILTERED,

--- a/modules/middleware/src/buildAggregations.js
+++ b/modules/middleware/src/buildAggregations.js
@@ -142,14 +142,13 @@ const injectNestedFiltersToAggs = ({ aggs, nestedSqonFilters }) => {
               [`${aggContent.nested.path}:${AGGS_WRAPPER_FILTERED}`]: {
                 filter: {
                   bool: {
-                    must: [
-                      opSwitch({
-                        nestedFields: [],
-                        filter: normalizeFilters(
-                          nestedSqonFilters[aggContent.nested.path],
-                        ),
-                      }),
-                    ],
+                    must: nestedSqonFilters[aggContent.nested.path].map(
+                      sqonFilter =>
+                        opSwitch({
+                          nestedFields: [],
+                          filter: normalizeFilters(sqonFilter),
+                        }),
+                    ),
                   },
                 },
                 aggs: injectNestedFiltersToAggs({
@@ -199,7 +198,7 @@ export default function({
       const parentPath = splitted.slice(0, splitted.length - 1).join('.');
       return {
         ...acc,
-        [parentPath]: filter,
+        [parentPath]: [...(acc[parentPath] || []), filter],
       };
     }, {});
   const aggs = Object.entries(graphqlFields).reduce(

--- a/modules/middleware/src/buildAggregations.js
+++ b/modules/middleware/src/buildAggregations.js
@@ -130,7 +130,7 @@ function wrapWithFilters({
   return aggregation;
 }
 
-const injectNestedFiltersToAggs = ({
+export const injectNestedFiltersToAggs = ({
   aggs,
   nestedSqonFilters,
   aggregationsFilterThemselves,
@@ -189,7 +189,7 @@ const injectNestedFiltersToAggs = ({
     } else {
       return acc;
     }
-  }, cloneDeep(aggs));
+  }, aggs);
 };
 
 export default function({

--- a/modules/middleware/src/buildAggregations.js
+++ b/modules/middleware/src/buildAggregations.js
@@ -203,6 +203,7 @@ export default function({
   aggregationsFilterThemselves,
   query,
 }) {
+  // TODO: support nested sqon operations
   const nestedSqonFilters = (sqon?.content || [])
     .filter(({ content }) => {
       const splitted = content.field.split('.');

--- a/modules/middleware/src/buildQuery/index.js
+++ b/modules/middleware/src/buildQuery/index.js
@@ -202,7 +202,7 @@ function getSetFilter({ nestedFields, filter, filter: { content } }) {
   });
 }
 
-function opSwitch({ nestedFields, filter }) {
+export const opSwitch = ({ nestedFields, filter }) => {
   const { op, content: { value } } = filter;
   if ([OR_OP, AND_OP, NOT_OP].includes(op)) {
     return getGroupFilter({ nestedFields, filter });
@@ -223,7 +223,7 @@ function opSwitch({ nestedFields, filter }) {
   } else {
     throw new Error('unknown op');
   }
-}
+};
 
 export default function({ nestedFields, filters: rawFilters }) {
   if (Object.keys(rawFilters || {}).length === 0) return {};

--- a/modules/middleware/test/buildAggregations.test.js
+++ b/modules/middleware/test/buildAggregations.test.js
@@ -164,6 +164,15 @@ test('buildAggregations should handle nested aggregations', () => {
 test('buildAggregations should handle nested aggregations with filters on same field', () => {
   const nestedFields = ['participants'];
   const input = {
+    sqon: {
+      op: 'and',
+      content: [
+        {
+          op: 'in',
+          content: { field: 'participants.kf_id', value: ['PT_87QW2JKA'] },
+        },
+      ],
+    },
     query: {
       bool: {
         must: [
@@ -220,6 +229,14 @@ test('buildAggregations should handle nested aggregations with filters on same f
 
 test('buildAggregations should handle `aggregations_filter_themselves` variable set to false', () => {
   let input = {
+    sqon: {
+      op: 'and',
+      content: [
+        { op: 'in', content: { field: 'acl', value: ['phs000178'] } },
+        { op: '>=', content: { field: 'mdx', value: 100 } },
+        { op: '<=', content: { field: 'mdx', value: 200 } },
+      ],
+    },
     nestedFields: [],
     graphqlFields: {
       mdx: {
@@ -235,17 +252,6 @@ test('buildAggregations should handle `aggregations_filter_themselves` variable 
         },
       },
     },
-    query: buildQuery({
-      nestedFields: [],
-      filters: {
-        op: 'and',
-        content: [
-          { op: 'in', content: { field: 'acl', value: ['phs000178'] } },
-          { op: '>=', content: { field: 'mdx', value: 100 } },
-          { op: '<=', content: { field: 'mdx', value: 200 } },
-        ],
-      },
-    }),
     aggregationsFilterThemselves: false,
   };
 
@@ -306,17 +312,14 @@ test('buildAggregations should handle `aggregations_filter_themselves` variable 
         },
       },
     },
-    query: buildQuery({
-      nestedFields: [],
-      filters: {
-        op: 'and',
-        content: [
-          { op: 'in', content: { field: 'acl', value: ['phs000178'] } },
-          { op: '>=', content: { field: 'mdx', value: 100 } },
-          { op: '<=', content: { field: 'mdx', value: 200 } },
-        ],
-      },
-    }),
+    sqon: {
+      op: 'and',
+      content: [
+        { op: 'in', content: { field: 'acl', value: ['phs000178'] } },
+        { op: '>=', content: { field: 'mdx', value: 100 } },
+        { op: '<=', content: { field: 'mdx', value: 200 } },
+      ],
+    },
     aggregationsFilterThemselves: true,
   };
 
@@ -332,10 +335,7 @@ test('buildAggregations should handle `aggregations_filter_themselves` variable 
 test('buildAggregations should handle queries not in a group', () => {
   const nestedFields = [];
   const input = {
-    query: buildQuery({
-      nestedFields,
-      filters: { op: 'in', content: { field: 'case', value: [1] } },
-    }),
+    sqon: { op: 'in', content: { field: 'case', value: [1] } },
     nestedFields,
     graphqlFields: {
       access: { buckets: { key: {} } },

--- a/modules/middleware/test/buildAggregations.test.js
+++ b/modules/middleware/test/buildAggregations.test.js
@@ -240,15 +240,17 @@ test('buildAggregations should handle nested aggregations with filters on same f
 });
 
 test('buildAggregations should handle `aggregations_filter_themselves` variable set to false', () => {
+  const sqon = {
+    op: 'and',
+    content: [
+      { op: 'in', content: { field: 'acl', value: ['phs000178'] } },
+      { op: '>=', content: { field: 'mdx', value: 100 } },
+      { op: '<=', content: { field: 'mdx', value: 200 } },
+    ],
+  };
   let input = {
-    sqon: {
-      op: 'and',
-      content: [
-        { op: 'in', content: { field: 'acl', value: ['phs000178'] } },
-        { op: '>=', content: { field: 'mdx', value: 100 } },
-        { op: '<=', content: { field: 'mdx', value: 200 } },
-      ],
-    },
+    sqon,
+    query: buildQuery({ nestedFields: [], filters: sqon }),
     nestedFields: [],
     graphqlFields: {
       mdx: {
@@ -308,6 +310,14 @@ test('buildAggregations should handle `aggregations_filter_themselves` variable 
 });
 
 test('buildAggregations should handle `aggregations_filter_themselves` variable set to true', () => {
+  const sqon = {
+    op: 'and',
+    content: [
+      { op: 'in', content: { field: 'acl', value: ['phs000178'] } },
+      { op: '>=', content: { field: 'mdx', value: 100 } },
+      { op: '<=', content: { field: 'mdx', value: 200 } },
+    ],
+  };
   let input = {
     nestedFields: [],
     graphqlFields: {
@@ -324,14 +334,8 @@ test('buildAggregations should handle `aggregations_filter_themselves` variable 
         },
       },
     },
-    sqon: {
-      op: 'and',
-      content: [
-        { op: 'in', content: { field: 'acl', value: ['phs000178'] } },
-        { op: '>=', content: { field: 'mdx', value: 100 } },
-        { op: '<=', content: { field: 'mdx', value: 200 } },
-      ],
-    },
+    sqon,
+    query: buildQuery({ nestedFields: [], filters: sqon }),
     aggregationsFilterThemselves: true,
   };
 
@@ -346,11 +350,13 @@ test('buildAggregations should handle `aggregations_filter_themselves` variable 
 
 test('buildAggregations should handle queries not in a group', () => {
   const nestedFields = [];
+  const sqon = {
+    op: 'and',
+    content: [{ op: 'in', content: { field: 'case', value: [1] } }],
+  };
   const input = {
-    sqon: {
-      op: 'and',
-      content: [{ op: 'in', content: { field: 'case', value: [1] } }],
-    },
+    sqon,
+    query: buildQuery({ nestedFields, filters: sqon }),
     nestedFields,
     graphqlFields: {
       access: { buckets: { key: {} } },
@@ -375,20 +381,23 @@ test('buildAggregations should handle queries not in a group', () => {
 });
 
 test('buildAggregations should drop nested sqon filters down to appropriate aggregation filters', () => {
-  const input = {
-    nestedFields: ['participants', 'participants.diagnoses'],
-    sqon: {
-      op: 'and',
-      content: [
-        {
-          op: 'in',
-          content: {
-            field: 'participants.diagnoses.mondo_id_diagnosis',
-            value: ['MONDO:0021637'],
-          },
+  const sqon = {
+    op: 'and',
+    content: [
+      {
+        op: 'in',
+        content: {
+          field: 'participants.diagnoses.mondo_id_diagnosis',
+          value: ['MONDO:0021637'],
         },
-      ],
-    },
+      },
+    ],
+  };
+  const nestedFields = ['participants', 'participants.diagnoses'];
+  const input = {
+    nestedFields,
+    sqon,
+    query: buildQuery({ nestedFields, filters: sqon }),
     graphqlFields: {
       participants__diagnoses__source_text_diagnosis: { buckets: { key: {} } },
     },
@@ -454,27 +463,30 @@ test('buildAggregations should drop nested sqon filters down to appropriate aggr
 });
 
 test('buildAggregations can drop nested sqon filters down to filters excluding aggregations that would filter themselves', () => {
+  const sqon = {
+    op: 'and',
+    content: [
+      {
+        op: 'in',
+        content: {
+          field: 'participants.diagnoses.mondo_id_diagnosis',
+          value: ['MONDO:0021637'],
+        },
+      },
+      {
+        op: 'in',
+        content: {
+          field: 'participants.diagnoses.source_text_diagnosis',
+          value: ['MONDO:0021637'],
+        },
+      },
+    ],
+  };
+  const nestedFields = ['participants', 'participants.diagnoses'];
   const input = {
-    nestedFields: ['participants', 'participants.diagnoses'],
-    sqon: {
-      op: 'and',
-      content: [
-        {
-          op: 'in',
-          content: {
-            field: 'participants.diagnoses.mondo_id_diagnosis',
-            value: ['MONDO:0021637'],
-          },
-        },
-        {
-          op: 'in',
-          content: {
-            field: 'participants.diagnoses.source_text_diagnosis',
-            value: ['MONDO:0021637'],
-          },
-        },
-      ],
-    },
+    nestedFields,
+    sqon,
+    query: buildQuery({ nestedFields, filters: sqon }),
     graphqlFields: {
       participants__diagnoses__source_text_diagnosis: { buckets: { key: {} } },
     },
@@ -587,27 +599,30 @@ test('buildAggregations can drop nested sqon filters down to filters excluding a
 });
 
 test('buildAggregations can drop nested sqon filters down to filters including aggregations that would filter themselves', () => {
+  const sqon = {
+    op: 'and',
+    content: [
+      {
+        op: 'in',
+        content: {
+          field: 'participants.diagnoses.mondo_id_diagnosis',
+          value: ['MONDO:0021637'],
+        },
+      },
+      {
+        op: 'in',
+        content: {
+          field: 'participants.diagnoses.source_text_diagnosis',
+          value: ['MONDO:0021637'],
+        },
+      },
+    ],
+  };
+  const nestedFields = ['participants', 'participants.diagnoses'];
   const input = {
-    nestedFields: ['participants', 'participants.diagnoses'],
-    sqon: {
-      op: 'and',
-      content: [
-        {
-          op: 'in',
-          content: {
-            field: 'participants.diagnoses.mondo_id_diagnosis',
-            value: ['MONDO:0021637'],
-          },
-        },
-        {
-          op: 'in',
-          content: {
-            field: 'participants.diagnoses.source_text_diagnosis',
-            value: ['MONDO:0021637'],
-          },
-        },
-      ],
-    },
+    nestedFields,
+    sqon,
+    query: buildQuery({ nestedFields, filters: sqon }),
     graphqlFields: {
       participants__diagnoses__source_text_diagnosis: { buckets: { key: {} } },
     },

--- a/modules/middleware/test/buildAggregations.test.js
+++ b/modules/middleware/test/buildAggregations.test.js
@@ -388,7 +388,7 @@ test('buildAggregations should drop nested sqon filters down to appropriate aggr
         op: 'in',
         content: {
           field: 'participants.diagnoses.mondo_id_diagnosis',
-          value: ['MONDO:0021637'],
+          value: ['SOME_VALUE'],
         },
       },
     ],
@@ -421,7 +421,7 @@ test('buildAggregations should drop nested sqon filters down to appropriate aggr
                     {
                       terms: {
                         'participants.diagnoses.mondo_id_diagnosis': [
-                          'MONDO:0021637',
+                          'SOME_VALUE',
                         ],
                         boost: 0,
                       },
@@ -470,14 +470,14 @@ test('buildAggregations can drop nested sqon filters down to filters excluding a
         op: 'in',
         content: {
           field: 'participants.diagnoses.mondo_id_diagnosis',
-          value: ['MONDO:0021637'],
+          value: ['SOME_VALUE'],
         },
       },
       {
         op: 'in',
         content: {
           field: 'participants.diagnoses.source_text_diagnosis',
-          value: ['MONDO:0021637'],
+          value: ['SOME_VALUE'],
         },
       },
     ],
@@ -515,7 +515,7 @@ test('buildAggregations can drop nested sqon filters down to filters excluding a
                                     {
                                       terms: {
                                         'participants.diagnoses.mondo_id_diagnosis': [
-                                          'MONDO:0021637',
+                                          'SOME_VALUE',
                                         ],
                                         boost: 0,
                                       },
@@ -551,7 +551,7 @@ test('buildAggregations can drop nested sqon filters down to filters excluding a
                             {
                               terms: {
                                 'participants.diagnoses.mondo_id_diagnosis': [
-                                  'MONDO:0021637',
+                                  'SOME_VALUE',
                                 ],
                                 boost: 0,
                               },
@@ -606,14 +606,14 @@ test('buildAggregations can drop nested sqon filters down to filters including a
         op: 'in',
         content: {
           field: 'participants.diagnoses.mondo_id_diagnosis',
-          value: ['MONDO:0021637'],
+          value: ['SOME_VALUE'],
         },
       },
       {
         op: 'in',
         content: {
           field: 'participants.diagnoses.source_text_diagnosis',
-          value: ['MONDO:0021637'],
+          value: ['SOME_VALUE'],
         },
       },
     ],
@@ -646,7 +646,7 @@ test('buildAggregations can drop nested sqon filters down to filters including a
                     {
                       terms: {
                         'participants.diagnoses.mondo_id_diagnosis': [
-                          'MONDO:0021637',
+                          'SOME_VALUE',
                         ],
                         boost: 0,
                       },
@@ -654,7 +654,7 @@ test('buildAggregations can drop nested sqon filters down to filters including a
                     {
                       terms: {
                         'participants.diagnoses.source_text_diagnosis': [
-                          'MONDO:0021637',
+                          'SOME_VALUE',
                         ],
                         boost: 0,
                       },
@@ -737,14 +737,14 @@ test('injectNestedFiltersToAggs should not be mutative', () => {
         op: 'in',
         content: {
           field: 'participants.diagnoses.mondo_id_diagnosis',
-          value: ['MONDO:0021637'],
+          value: ['SOME_VALUE'],
         },
       },
       {
         op: 'in',
         content: {
           field: 'participants.diagnoses.source_text_diagnosis',
-          value: ['MONDO:0021637'],
+          value: ['SOME_VALUE'],
         },
       },
     ],


### PR DESCRIPTION
handles this edge case: https://github.com/kids-first/kf-portal-ui/issues/488

The solution was to post process the aggs before feeding into Elasticsearch, by finding aggregation fields that share a direct parent with any query, and drop such queries down to that aggregation as filters. In effect, this creates a new layer of temporary aggregation for the filters for every aggregation field to ensure nothing is missed.

If `aggregationsFilterThemselves` is falsey, the injection will exclude filters that match the aggregation field exactly.

Tried to do it TDD so we got 4 new test cases added. No logical change to existing tests, other than matching up with new function signature.