### PR TITLE
🐛 handles sqon with no fields specified and organizes file structures

### DIFF
--- a/integration-tests/import/package.json
+++ b/integration-tests/import/package.json
@@ -13,7 +13,7 @@
     }
   },
   "dependencies": {
-    "@arranger/components": "^0.4.3"
+    "@arranger/components": "^0.4.4-beta"
   },
   "devDependencies": {
     "@babel/core": "7.0.0-beta.40",
@@ -24,5 +24,5 @@
     "jest-localstorage-mock": "^2.2.0",
     "regenerator-runtime": "^0.11.1"
   },
-  "version": "0.4.3"
+  "version": "0.4.4-beta"
 }

--- a/integration-tests/server/package.json
+++ b/integration-tests/server/package.json
@@ -5,7 +5,7 @@
     "test": "mocha --require @babel/register"
   },
   "dependencies": {
-    "@arranger/server": "^0.4.3",
+    "@arranger/server": "^0.4.4-beta",
     "body-parser": "^1.18.2",
     "elasticsearch": "^14.0.0"
   },
@@ -19,5 +19,5 @@
     "mocha": "^5.0.4",
     "regenerator-runtime": "^0.11.1"
   },
-  "version": "0.4.3"
+  "version": "0.4.4-beta"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "lerna": "2.5.1",
-  "version": "0.4.3",
+  "version": "0.4.4-beta",
   "packages": [
     "modules/*",
     "integration-tests/*"

--- a/modules/components/package.json
+++ b/modules/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arranger/components",
-  "version": "0.4.3",
+  "version": "0.4.4-beta",
   "description": "Data Portal Components",
   "main": "dist/index.js",
   "publishConfig": {
@@ -59,7 +59,7 @@
     "react-dom": "^16.3.0"
   },
   "dependencies": {
-    "@arranger/mapping-utils": "^0.4.3",
+    "@arranger/mapping-utils": "^0.4.4-beta",
     "ajv": "^6.1.1",
     "babel-polyfill": "^6.26.0",
     "classnames": "^2.2.5",

--- a/modules/mapping-utils/package.json
+++ b/modules/mapping-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arranger/mapping-utils",
-  "version": "0.4.3",
+  "version": "0.4.4-beta",
   "description": "Transform Elasticsearch mappings",
   "main": "dist/index.js",
   "publishConfig": {
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/overture-stack/arranger#readme",
   "dependencies": {
-    "@arranger/middleware": "^0.4.3",
+    "@arranger/middleware": "^0.4.4-beta",
     "babel-polyfill": "^6.26.0",
     "elasticsearch": "^14.0.0",
     "graphql-fields": "^1.0.2",

--- a/modules/middleware/package.json
+++ b/modules/middleware/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arranger/middleware",
-  "version": "0.4.3",
+  "version": "0.4.4-beta",
   "description": "Arranger Middleware",
   "main": "dist/index.js",
   "publishConfig": {

--- a/modules/middleware/src/buildAggregations/getNestedSqonFilters.js
+++ b/modules/middleware/src/buildAggregations/getNestedSqonFilters.js
@@ -1,0 +1,18 @@
+export default ({ sqon = null, nestedFields }) =>
+  (sqon?.content || [])
+    .filter(({ content }) => {
+      const splitted = content?.field?.split('.') || '';
+      return content?.field && splitted.length
+        ? nestedFields.includes(
+            splitted.slice(0, splitted.length - 1).join('.'),
+          )
+        : false;
+    })
+    .reduce((acc, filter) => {
+      const splitted = filter.content.field.split('.');
+      const parentPath = splitted.slice(0, splitted.length - 1).join('.');
+      return {
+        ...acc,
+        [parentPath]: [...(acc[parentPath] || []), filter],
+      };
+    }, {});

--- a/modules/middleware/src/buildAggregations/injectNestedFiltersToAggs.js
+++ b/modules/middleware/src/buildAggregations/injectNestedFiltersToAggs.js
@@ -1,0 +1,72 @@
+import { opSwitch } from '../buildQuery';
+import normalizeFilters from '../buildQuery/normalizeFilters';
+import { AGGS_WRAPPER_FILTERED } from '../constants';
+
+/*
+ * due to this problem: https://github.com/kids-first/kf-portal-ui/issues/488
+ * queries that are on a term that shares a parent with a aggregation field
+ * needs to be dropped down to the aggregation level as a filter.
+ */
+const injectNestedFiltersToAggs = ({
+  aggs,
+  nestedSqonFilters,
+  aggregationsFilterThemselves,
+}) =>
+  Object.entries(aggs).reduce((acc, [aggName, aggContent]) => {
+    const skipToNextLevel = () => ({
+      ...acc,
+      [aggName]: {
+        ...aggContent,
+        aggs: injectNestedFiltersToAggs({
+          aggs: aggContent.aggs,
+          nestedSqonFilters,
+          aggregationsFilterThemselves,
+        }),
+      },
+    });
+    const wrapInFilterAgg = () => ({
+      ...acc,
+      [aggName]: {
+        ...aggContent,
+        aggs: {
+          [`${aggContent.nested.path}:${AGGS_WRAPPER_FILTERED}`]: {
+            filter: {
+              bool: {
+                must: nestedSqonFilters[aggContent.nested.path]
+                  .filter(
+                    sqonFilter =>
+                      aggregationsFilterThemselves ||
+                      aggName.split(':')[0] !== sqonFilter.content.field,
+                  )
+                  .map(sqonFilter =>
+                    opSwitch({
+                      nestedFields: [],
+                      filter: normalizeFilters(sqonFilter),
+                    }),
+                  ),
+              },
+            },
+            aggs: injectNestedFiltersToAggs({
+              aggs: aggContent.aggs,
+              nestedSqonFilters,
+              aggregationsFilterThemselves,
+            }),
+          },
+        },
+      },
+    });
+
+    if (aggContent.global || aggContent.filter) {
+      return skipToNextLevel();
+    } else if (aggContent.nested) {
+      if (nestedSqonFilters[aggContent.nested.path]) {
+        return wrapInFilterAgg();
+      } else {
+        return skipToNextLevel();
+      }
+    } else {
+      return acc;
+    }
+  }, aggs);
+
+export default injectNestedFiltersToAggs;

--- a/modules/middleware/test/buildAggregations/buildAggregations.test.js
+++ b/modules/middleware/test/buildAggregations/buildAggregations.test.js
@@ -1,8 +1,5 @@
-import buildAggregations, {
-  injectNestedFiltersToAggs,
-} from '../src/buildAggregations.js';
-import buildQuery from '../src/buildQuery';
-import { cloneDeep } from 'lodash';
+import buildAggregations from '../../src/buildAggregations';
+import buildQuery from '../../src/buildQuery';
 
 test('buildAggregations should handle nested aggregations', () => {
   const nestedFields = [
@@ -693,64 +690,4 @@ test('buildAggregations can drop nested sqon filters down to filters including a
   };
   const actualOutput = buildAggregations(input);
   expect(actualOutput).toEqual(expectedOutput);
-});
-
-test('injectNestedFiltersToAggs should not be mutative', () => {
-  const aggs = {
-    nested: {
-      path: 'participants',
-    },
-    aggs: {
-      'participants.diagnoses.source_text_diagnosis:nested': {
-        nested: {
-          path: 'participants.diagnoses',
-        },
-        aggs: {
-          'participants.diagnoses.source_text_diagnosis': {
-            aggs: {
-              rn: {
-                reverse_nested: {},
-              },
-            },
-            terms: {
-              field: 'participants.diagnoses.source_text_diagnosis',
-              size: 300000,
-            },
-          },
-          'participants.diagnoses.source_text_diagnosis:missing': {
-            aggs: {
-              rn: {
-                reverse_nested: {},
-              },
-            },
-            missing: {
-              field: 'participants.diagnoses.source_text_diagnosis',
-            },
-          },
-        },
-      },
-    },
-  };
-  const nestedSqonFilters = {
-    'participants.diagnoses': [
-      {
-        op: 'in',
-        content: {
-          field: 'participants.diagnoses.mondo_id_diagnosis',
-          value: ['SOME_VALUE'],
-        },
-      },
-      {
-        op: 'in',
-        content: {
-          field: 'participants.diagnoses.source_text_diagnosis',
-          value: ['SOME_VALUE'],
-        },
-      },
-    ],
-  };
-  const expectedOriginalAggs = cloneDeep(aggs);
-  injectNestedFiltersToAggs({ aggs, nestedSqonFilters });
-
-  expect(aggs).toEqual(expectedOriginalAggs);
 });

--- a/modules/middleware/test/buildAggregations/getNestedSqonFilters.test.js
+++ b/modules/middleware/test/buildAggregations/getNestedSqonFilters.test.js
@@ -1,0 +1,32 @@
+import getNestedSqonFilters from '../../src/buildAggregations/getNestedSqonFilters';
+
+test('getNestedSqonFilters should be able to extract filters applied on nested fields', () => {
+  const sqon = {
+    op: 'and',
+    content: [
+      { op: 'in', content: { field: 'a', value: [] } },
+      { op: 'in', content: { field: 'a', value: [] } },
+      { op: 'in', content: { field: 'a.c', value: [] } },
+      { op: 'in', content: { field: 'a.b.c', value: [] } },
+      { op: 'in', content: { field: 'a.b.d', value: [] } },
+    ],
+  };
+  const nestedFields = ['a', 'a.b'];
+  const expectedOutput = {
+    a: [{ op: 'in', content: { field: 'a.c', value: [] } }],
+    'a.b': [
+      { op: 'in', content: { field: 'a.b.c', value: [] } },
+      { op: 'in', content: { field: 'a.b.d', value: [] } },
+    ],
+  };
+  expect(getNestedSqonFilters({ sqon, nestedFields })).toEqual(expectedOutput);
+});
+
+test('getNestedSqonFilters should handle sqon contents without fields', () => {
+  const sqon = {
+    op: 'and',
+    content: [{}],
+  };
+  const nestedFields = [];
+  expect(getNestedSqonFilters({ sqon, nestedFields })).toEqual({});
+});

--- a/modules/middleware/test/buildAggregations/injectNestedFiltersToAggs.test.js
+++ b/modules/middleware/test/buildAggregations/injectNestedFiltersToAggs.test.js
@@ -1,0 +1,62 @@
+import { cloneDeep } from 'lodash';
+import injectNestedFiltersToAggs from '../../src/buildAggregations/injectNestedFiltersToAggs';
+
+test('injectNestedFiltersToAggs should not be mutative', () => {
+  const aggs = {
+    nested: {
+      path: 'participants',
+    },
+    aggs: {
+      'participants.diagnoses.source_text_diagnosis:nested': {
+        nested: {
+          path: 'participants.diagnoses',
+        },
+        aggs: {
+          'participants.diagnoses.source_text_diagnosis': {
+            aggs: {
+              rn: {
+                reverse_nested: {},
+              },
+            },
+            terms: {
+              field: 'participants.diagnoses.source_text_diagnosis',
+              size: 300000,
+            },
+          },
+          'participants.diagnoses.source_text_diagnosis:missing': {
+            aggs: {
+              rn: {
+                reverse_nested: {},
+              },
+            },
+            missing: {
+              field: 'participants.diagnoses.source_text_diagnosis',
+            },
+          },
+        },
+      },
+    },
+  };
+  const nestedSqonFilters = {
+    'participants.diagnoses': [
+      {
+        op: 'in',
+        content: {
+          field: 'participants.diagnoses.mondo_id_diagnosis',
+          value: ['SOME_VALUE'],
+        },
+      },
+      {
+        op: 'in',
+        content: {
+          field: 'participants.diagnoses.source_text_diagnosis',
+          value: ['SOME_VALUE'],
+        },
+      },
+    ],
+  };
+  const expectedOriginalAggs = cloneDeep(aggs);
+  injectNestedFiltersToAggs({ aggs, nestedSqonFilters });
+
+  expect(aggs).toEqual(expectedOriginalAggs);
+});

--- a/modules/schema/package.json
+++ b/modules/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arranger/schema",
-  "version": "0.4.3",
+  "version": "0.4.4-beta",
   "description": "GraphQL Schema for Data Portals",
   "main": "dist/index.js",
   "publishConfig": {
@@ -24,8 +24,8 @@
     "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0"
   },
   "dependencies": {
-    "@arranger/mapping-utils": "^0.4.3",
-    "@arranger/middleware": "^0.4.3",
+    "@arranger/mapping-utils": "^0.4.4-beta",
+    "@arranger/middleware": "^0.4.4-beta",
     "babel-polyfill": "^6.26.0",
     "elasticsearch": "^14.0.0",
     "graphql-middleware": "1.3.1",

--- a/modules/server/package.json
+++ b/modules/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arranger/server",
-  "version": "0.4.3",
+  "version": "0.4.4-beta",
   "description": "GraphQL Server",
   "main": "dist/index.js",
   "bin": {
@@ -26,9 +26,9 @@
   },
   "homepage": "https://github.com/overture-stack/arranger#readme",
   "dependencies": {
-    "@arranger/mapping-utils": "^0.4.3",
-    "@arranger/middleware": "^0.4.3",
-    "@arranger/schema": "^0.4.3",
+    "@arranger/mapping-utils": "^0.4.4-beta",
+    "@arranger/middleware": "^0.4.4-beta",
+    "@arranger/schema": "^0.4.4-beta",
     "apollo-server-express": "^1.3.1",
     "babel-polyfill": "^6.26.0",
     "body-parser": "^1.18.2",


### PR DESCRIPTION
fixes the break caused by https://github.com/overture-stack/arranger/pull/428

Things done: 
- split out `getNestedSqonFilters` for testing and adds falsey check on `content.field` there
- general file organization (sorry for the big diff...)
- created a `0.4.4-beta` release for testing in beta portal (we'll bump this to 0.4.4 after merging to master)