### PR TITLE
⚡️ hits resolution performance boost

### DIFF
--- a/modules/mapping-utils/src/resolveHits.js
+++ b/modules/mapping-utils/src/resolveHits.js
@@ -102,7 +102,7 @@ export const hitsToEdges = ({
                       nestedFields,
                       parent: fullPath,
                     });
-              return Object.assign({}, acc, resolvedNested);
+              return Object.assign(acc, resolvedNested);
             }, {});
           };
           let source = x._source;
@@ -120,8 +120,8 @@ export const hitsToEdges = ({
                 )
               : [],
             node: Object.assign(
-              { id: x._id },
               source,
+              { id: x._id },
               nested_nodes,
               copied_to_nodes,
             ),
@@ -200,8 +200,18 @@ export default ({ type, Parallel }) => async (
   });
 
   return {
-    edges: () =>
-      hitsToEdges({ hits, nestedFields, Parallel, copyToSourceFields }),
+    edges: () => {
+      console.time('hitsToEdges');
+      return hitsToEdges({
+        hits,
+        nestedFields,
+        Parallel,
+        copyToSourceFields,
+      }).then(result => {
+        console.timeEnd('hitsToEdges');
+        return result;
+      });
+    },
     total: () => hits.total,
   };
 };

--- a/modules/mapping-utils/src/resolveHits.js
+++ b/modules/mapping-utils/src/resolveHits.js
@@ -205,8 +205,6 @@ export default ({ type, Parallel }) => async (
 
   const copyToSourceFields = findCopyToSourceFields(type.mapping);
 
-  const timer = `elasticsearch_${Date.now()}`;
-  console.time(timer);
   let { hits } = await es.search({
     index: type.index,
     type: type.es_type,
@@ -219,23 +217,15 @@ export default ({ type, Parallel }) => async (
     track_scores: !!score,
     body,
   });
-  console.timeEnd(timer);
 
   return {
-    edges: () => {
-      const time = Date.now();
-      console.time(`hitsToEdges_${time}`);
-      return hitsToEdges({
+    edges: () =>
+      hitsToEdges({
         hits,
         nestedFields,
         Parallel,
         copyToSourceFields,
-      }).then(result => {
-        console.timeEnd(`hitsToEdges_${time}`);
-        console.log('result.length: ', result.length);
-        return result;
-      });
-    },
+      }),
     total: () => hits.total,
   };
 };

--- a/modules/mapping-utils/src/resolveHits.js
+++ b/modules/mapping-utils/src/resolveHits.js
@@ -120,7 +120,7 @@ export const hitsToEdges = ({
                 )
               : [],
             node: Object.assign(
-              source,
+              source, // we're not afraid of mutating source here!
               { id: x._id },
               nested_nodes,
               copied_to_nodes,

--- a/modules/mapping-utils/src/resolveHits.js
+++ b/modules/mapping-utils/src/resolveHits.js
@@ -147,9 +147,7 @@ export const hitsToEdges = ({
                 };
               });
             })
-            .then(edges => {
-              resolve(edges);
-            });
+            .then(resolve);
         }),
     ),
   ).then(chunks => chunks.reduce((acc, chunk) => acc.concat(chunk)));
@@ -207,6 +205,8 @@ export default ({ type, Parallel }) => async (
 
   const copyToSourceFields = findCopyToSourceFields(type.mapping);
 
+  const timer = `elasticsearch_${Date.now()}`;
+  console.time(timer);
   let { hits } = await es.search({
     index: type.index,
     type: type.es_type,
@@ -219,6 +219,7 @@ export default ({ type, Parallel }) => async (
     track_scores: !!score,
     body,
   });
+  console.timeEnd(timer);
 
   return {
     edges: () => {

--- a/modules/mapping-utils/src/resolveHits.js
+++ b/modules/mapping-utils/src/resolveHits.js
@@ -22,7 +22,11 @@ export const hitsToEdges = ({
   copyToSourceFields = {},
   systemCores = process?.env?.SYSTEM_CORES || 2,
 }) => {
-  //Parallel.spawn output has a .then but it's not returning an actual promise
+  /*
+    If there's a large request, we'll trigger ludicrous mode and do some parallel
+    map-reduce based on # of cores available. Otherwise, only one child-process
+    is spawn for compute
+  */
   const dataSize = hits.hits.length;
   const chunks = chunk(
     hits.hits,
@@ -33,6 +37,7 @@ export const hitsToEdges = ({
   return Promise.all(
     chunks.map(
       chunk =>
+        //Parallel.spawn output has a .then but it's not returning an actual promise
         new Promise(resolve => {
           new Parallel({ hits: chunk, nestedFields, copyToSourceFields })
             .spawn(({ hits, nestedFields, copyToSourceFields }) => {

--- a/modules/server/src/download/index.js
+++ b/modules/server/src/download/index.js
@@ -7,17 +7,21 @@ import columnsToGraphql from '@arranger/mapping-utils/dist/utils/columnsToGraphq
 
 import getAllData from '../utils/getAllData';
 import dataToTSV from '../utils/dataToTSV';
+import { DOWNLOAD_STREAM_BUFFER_SIZE } from '../utils/config';
+
+const DOWNLOAD_STREAM_BUFFER_SIZE = 2000;
 
 export default function({ projectId, io }) {
   function makeTSV(args) {
     return getAllData({
+      chunkSize: DOWNLOAD_STREAM_BUFFER_SIZE,
       projectId,
       ...args,
       ...columnsToGraphql({
         sqon: args.sqon,
         config: { columns: args.columns, type: args.index },
         sort: args.sort || [],
-        first: 1000,
+        first: DOWNLOAD_STREAM_BUFFER_SIZE,
       }),
     }).pipe(dataToTSV(args));
   }

--- a/modules/server/src/download/index.js
+++ b/modules/server/src/download/index.js
@@ -9,8 +9,6 @@ import getAllData from '../utils/getAllData';
 import dataToTSV from '../utils/dataToTSV';
 import { DOWNLOAD_STREAM_BUFFER_SIZE } from '../utils/config';
 
-const DOWNLOAD_STREAM_BUFFER_SIZE = 2000;
-
 export default function({ projectId, io }) {
   function makeTSV(args) {
     return getAllData({

--- a/modules/server/src/download/index.js
+++ b/modules/server/src/download/index.js
@@ -57,6 +57,7 @@ export default function({ projectId, io }) {
   router.use(bodyParser.urlencoded({ extended: true }));
 
   router.post('/', async function(req, res) {
+    console.time('download');
     const { params, downloadKey } = req.body;
     const { files, fileName = 'file.tar.gz', mock, chunkSize } = JSON.parse(
       params,
@@ -84,9 +85,10 @@ export default function({ projectId, io }) {
         'Content-disposition',
         `attachment; filename=${responseFileName}`,
       );
-      output
-        .pipe(res)
-        .on('finish', () => io.emit(`server::download::${downloadKey}`));
+      output.pipe(res).on('finish', () => {
+        console.timeEnd('download');
+        io.emit(`server::download::${downloadKey}`);
+      });
     }
   });
 

--- a/modules/server/src/download/index.js
+++ b/modules/server/src/download/index.js
@@ -60,7 +60,6 @@ export default function({ projectId, io }) {
   router.use(bodyParser.urlencoded({ extended: true }));
 
   router.post('/', async function(req, res) {
-    console.time('download');
     const { params, downloadKey } = req.body;
     const { files, fileName = 'file.tar.gz', mock, chunkSize } = JSON.parse(
       params,
@@ -89,7 +88,6 @@ export default function({ projectId, io }) {
         `attachment; filename=${responseFileName}`,
       );
       output.pipe(res).on('finish', () => {
-        console.timeEnd('download');
         io.emit(`server::download::${downloadKey}`);
       });
     }

--- a/modules/server/src/download/index.js
+++ b/modules/server/src/download/index.js
@@ -10,9 +10,9 @@ import dataToTSV from '../utils/dataToTSV';
 import { DOWNLOAD_STREAM_BUFFER_SIZE } from '../utils/config';
 
 export default function({ projectId, io }) {
+  console.log('DOWNLOAD_STREAM_BUFFER_SIZE: ', DOWNLOAD_STREAM_BUFFER_SIZE);
   function makeTSV(args) {
     return getAllData({
-      chunkSize: DOWNLOAD_STREAM_BUFFER_SIZE,
       projectId,
       ...args,
       ...columnsToGraphql({
@@ -21,6 +21,7 @@ export default function({ projectId, io }) {
         sort: args.sort || [],
         first: DOWNLOAD_STREAM_BUFFER_SIZE,
       }),
+      chunkSize: DOWNLOAD_STREAM_BUFFER_SIZE,
     }).pipe(dataToTSV(args));
   }
 

--- a/modules/server/src/utils/config.js
+++ b/modules/server/src/utils/config.js
@@ -4,3 +4,5 @@ export const PROJECT_ID = process.env.PROJECT_ID;
 export const PING_MS = process.env.PING_MS || 2200;
 export const ES_LOG = process.env.ES_LOG?.split?.(',') || 'error';
 export const MAX_LIVE_VERSIONS = process.env.MAX_LIVE_VERSIONS || 3;
+export const DOWNLOAD_STREAM_BUFFER_SIZE =
+  process.env.DOWNLOAD_STREAM_BUFFER_SIZE || 2000;

--- a/modules/server/src/utils/dataToTSV.js
+++ b/modules/server/src/utils/dataToTSV.js
@@ -106,8 +106,6 @@ export default function({ columns, index, uniqueBy, emptyValue = '--' }) {
   let isFirst = true;
 
   return through2.obj(function(data, enc, callback) {
-    const timer = `dataToTSV_${Date.now()}`;
-    console.time(timer);
     if (isFirst) {
       isFirst = false;
       this.push(columnsToHeader({ columns }));
@@ -117,7 +115,6 @@ export default function({ columns, index, uniqueBy, emptyValue = '--' }) {
 
     if (rows) {
       this.push(rows);
-      console.timeEnd(timer);
     }
 
     callback();

--- a/modules/server/src/utils/dataToTSV.js
+++ b/modules/server/src/utils/dataToTSV.js
@@ -106,6 +106,8 @@ export default function({ columns, index, uniqueBy, emptyValue = '--' }) {
   let isFirst = true;
 
   return through2.obj(function(data, enc, callback) {
+    const timer = `dataToTSV_${Date.now()}`;
+    console.time(timer);
     if (isFirst) {
       isFirst = false;
       this.push(columnsToHeader({ columns }));
@@ -115,6 +117,7 @@ export default function({ columns, index, uniqueBy, emptyValue = '--' }) {
 
     if (rows) {
       this.push(rows);
+      console.timeEnd(timer);
     }
 
     callback();


### PR DESCRIPTION
**What was done**
Due to a large amount of data tranformation happening in the hits resolver (`modules/mapping-utils/src/resolveHits.js`), file download is extremely slow. To address this, the following changes were made:

1) A slight modification to the resolveNested function. The original had a very mutation-free approach that creates a new accumulator on every iteration, which implied an iteration over previously accumulated results. Removing this operation significantly improves the performance (consider this benchmark: https://www.measurethat.net/Benchmarks/ShowResult/27779). Only ephemeral mutation is added for this, so all existing tests passed. However, to be extra confident, I would like to get some tests from @cy written to assure accuracy when the copy_to field is involved.

2) Parallelizing the processing of hits. Fortunately, the mapping operations were independent of each other, so we were are able to **perform this operation in multiple parallel processes and combine the output** at the end. As there are overheads associated with running too many processes, this "ludicrous mode" is **only triggered if there are more than 1000 entries**, otherwise only one new process is spawn. The **number of parallel process depends on an environment variable for # of cores** available in the system, with a **default fallback to 2**. With two processes available, we also **increased the default stream buffer size from 1000 to 2000** to increase the gains in processing power and decrease other overheads.

**Benchmark result**
On my local machine, file download time of 15,838 entries (with some nested data) was reduced from 91687ms (1.5 minutes) to 37812ms (37 seconds). Total hits resolution compute time was reduced from 1 minute to 10 seconds.

The remaining time is attributed to the tsv generation and awaiting data from elasticsearch.