### PR TITLE
fixes histogram query not showing

### DIFF
--- a/modules/mapping-utils/src/resolveAggregations.js
+++ b/modules/mapping-utils/src/resolveAggregations.js
@@ -28,10 +28,17 @@ export default type => async (
   const resolvedFilter = await resolveSetsInSqon({ sqon: filters, es });
 
   const query = buildQuery({ nestedFields, filters: resolvedFilter });
+
+  /**
+   * TODO: getFields does not support aliased fields, so we are unable to
+   * serve multiple aggregations of the same type for a given field.
+   * Library issue: https://github.com/robrichard/graphql-fields/issues/18
+   */
+  const graphqlFields = getFields(info, {}, { processArguments: true });
   const aggs = buildAggregations({
     query,
     sqon: resolvedFilter,
-    graphqlFields: getFields(info),
+    graphqlFields,
     nestedFields,
     aggregationsFilterThemselves: aggregations_filter_themselves,
   });

--- a/modules/middleware/src/buildAggregations/createFieldAggregation.js
+++ b/modules/middleware/src/buildAggregations/createFieldAggregation.js
@@ -1,0 +1,54 @@
+import { get } from 'lodash';
+import { STATS, HISTOGRAM, BUCKETS } from '../constants';
+
+const MAX_AGGREGATION_SIZE = 300000;
+const HISTOGRAM_INTERVAL_DEFAULT = 1000;
+
+const createNumericAggregation = ({ type, field, graphqlField }) => {
+  const args = get(graphqlField, [type, '__arguments', 0]) || {};
+  return {
+    [`${field}:${type}`]: {
+      [type]: {
+        field,
+        ...(type === HISTOGRAM
+          ? {
+              interval:
+                get(args, 'interval.value') || HISTOGRAM_INTERVAL_DEFAULT,
+            }
+          : {}),
+      },
+    },
+  };
+};
+
+const createTermAggregation = ({ field, isNested }) => {
+  return {
+    [field]: {
+      ...(isNested ? { aggs: { rn: { reverse_nested: {} } } } : {}),
+      terms: { field, size: MAX_AGGREGATION_SIZE },
+    },
+    [`${field}:missing`]: {
+      ...(isNested ? { aggs: { rn: { reverse_nested: {} } } } : {}),
+      missing: { field: field },
+    },
+  };
+};
+
+/**
+ * graphqlFields: output from `graphql-fields` (https://github.com/robrichard/graphql-fields)
+ */
+export default ({ field, graphqlField = {}, isNested = false }) => {
+  const types = [BUCKETS, STATS, HISTOGRAM].filter(t => graphqlField[t]);
+  return types.reduce((acc, type) => {
+    if (type === BUCKETS) {
+      return Object.assign(acc, createTermAggregation({ field, isNested }));
+    } else if ([STATS, HISTOGRAM].includes(type)) {
+      return Object.assign(
+        acc,
+        createNumericAggregation({ type, field, graphqlField }),
+      );
+    } else {
+      return acc;
+    }
+  }, {});
+};

--- a/modules/middleware/test/buildAggregations/createFieldAggregation.test.js
+++ b/modules/middleware/test/buildAggregations/createFieldAggregation.test.js
@@ -1,0 +1,29 @@
+import createFieldAggregation from '../../src/buildAggregations/createFieldAggregation';
+
+test('it should handle multiple aggregation types per field', () => {
+  const input = {
+    field: 'sequencing_experiments.mean_depth',
+    graphqlField: {
+      stats: { max: {} },
+      histogram: {
+        buckets: { doc_count: {}, key: {} },
+        __arguments: [{ interval: { kind: 'IntValue', value: '5' } }],
+      },
+    },
+    isNested: 1,
+  };
+
+  const output = {
+    'sequencing_experiments.mean_depth:stats': {
+      stats: { field: 'sequencing_experiments.mean_depth' },
+    },
+    'sequencing_experiments.mean_depth:histogram': {
+      histogram: {
+        field: 'sequencing_experiments.mean_depth',
+        interval: '5',
+      },
+    },
+  };
+
+  expect(createFieldAggregation(input)).toEqual(output);
+});

--- a/modules/schema/package.json
+++ b/modules/schema/package.json
@@ -30,8 +30,8 @@
     "elasticsearch": "^14.0.0",
     "graphql-middleware": "1.3.1",
     "graphql-scalars": "^0.1.5",
-    "graphql-tools": "3.0.4",
-    "graphql-type-json": "^0.1.4",
+    "graphql-tools": "^4.0.0",
+    "graphql-type-json": "^0.2.1",
     "lodash": "^4.17.4",
     "paralleljs": "^0.2.1",
     "uuid": "^3.2.1"


### PR DESCRIPTION
Issue identified: 
1) `createAggregation` was using `Array.find` to identify the aggregation type requested, which only picks up the first type. 
Solution: `createAggregation` was stripped out as `createFieldAggregation`, updated to use `Array.reduce` to iterate over each aggregation type and produce the ES aggregation accordingly.
2) Aggregation query arguments were not passed being processed, hence not available to `createNumericAggregation`. 
Solution: as per `graphql-fields`'s doc, `{ processArguments: true }` needed to be passed, and arguments are passed down under `__arguments` in the resulting field object.

Additional issue: `getFields` from `graphql-fields` does not handle graphql alias, preventing resolution of multiple aggregations of the same type on the same field. A contribution to third-party issue https://github.com/robrichard/graphql-fields/issues/18 is necessary before this can be incorporated.