### PR TITLE
v1.0.36 - fix range filter clear link

### DIFF
--- a/integration-tests/import/package.json
+++ b/integration-tests/import/package.json
@@ -14,7 +14,7 @@
     "testURL": "http://localhost/"
   },
   "dependencies": {
-    "@arranger/components": "^1.0.35"
+    "@arranger/components": "^1.0.36"
   },
   "devDependencies": {
     "@babel/core": "7.0.0-beta.40",
@@ -25,5 +25,5 @@
     "jest-localstorage-mock": "^2.2.0",
     "regenerator-runtime": "^0.11.1"
   },
-  "version": "1.0.35"
+  "version": "1.0.36"
 }

--- a/integration-tests/server/package.json
+++ b/integration-tests/server/package.json
@@ -5,7 +5,7 @@
     "test": "mocha --require @babel/register"
   },
   "dependencies": {
-    "@arranger/server": "^1.0.35",
+    "@arranger/server": "^1.0.36",
     "body-parser": "^1.18.2",
     "elasticsearch": "^14.0.0"
   },
@@ -19,5 +19,5 @@
     "mocha": "^5.0.4",
     "regenerator-runtime": "^0.11.1"
   },
-  "version": "1.0.35"
+  "version": "1.0.36"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
   "lerna": "2.5.1",
-  "version": "1.0.35",
+  "version": "1.0.36",
   "packages": [
     "modules/admin",
     "modules/*",

--- a/modules/admin-ui/package.json
+++ b/modules/admin-ui/package.json
@@ -1,9 +1,9 @@
 {
   "name": "@arranger/admin-ui",
-  "version": "1.0.35",
+  "version": "1.0.36",
   "private": true,
   "dependencies": {
-    "@arranger/admin": "^1.0.35",
+    "@arranger/admin": "^1.0.36",
     "@types/react-redux": "^6.0.9",
     "@types/react-router-dom": "^4.3.1",
     "@types/react-table": "^6.7.14",

--- a/modules/admin/package.json
+++ b/modules/admin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arranger/admin",
-  "version": "1.0.35",
+  "version": "1.0.36",
   "description": "Admin API for the Arranger server in graphql",
   "engineStrict": true,
   "engines": {
@@ -50,8 +50,8 @@
   "author": "Minh Ha",
   "license": "APLv2",
   "dependencies": {
-    "@arranger/mapping-utils": "^1.0.35",
-    "@arranger/schema": "^1.0.35",
+    "@arranger/mapping-utils": "^1.0.36",
+    "@arranger/schema": "^1.0.36",
     "@types/elasticsearch": "^5.0.26",
     "apollo-link-http": "^1.5.5",
     "apollo-server": "^2.1.0",

--- a/modules/components/package.json
+++ b/modules/components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arranger/components",
-  "version": "1.0.35",
+  "version": "1.0.36",
   "description": "Data Portal Components",
   "main": "dist/index.js",
   "publishConfig": {
@@ -61,7 +61,7 @@
     "react-dom": "^16.3.0"
   },
   "dependencies": {
-    "@arranger/mapping-utils": "^1.0.35",
+    "@arranger/mapping-utils": "^1.0.36",
     "ajv": "^6.1.1",
     "babel-polyfill": "^6.26.0",
     "classnames": "^2.2.5",

--- a/modules/mapping-utils/package.json
+++ b/modules/mapping-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arranger/mapping-utils",
-  "version": "1.0.35",
+  "version": "1.0.36",
   "description": "Transform Elasticsearch mappings",
   "main": "dist/index.js",
   "publishConfig": {
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/overture-stack/arranger#readme",
   "dependencies": {
-    "@arranger/middleware": "^1.0.35",
+    "@arranger/middleware": "^1.0.36",
     "babel-polyfill": "^6.26.0",
     "elasticsearch": "^14.0.0",
     "graphql-fields": "^1.0.2",

--- a/modules/middleware/package.json
+++ b/modules/middleware/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arranger/middleware",
-  "version": "1.0.35",
+  "version": "1.0.36",
   "description": "Arranger Middleware",
   "main": "dist/index.js",
   "publishConfig": {

--- a/modules/schema/package.json
+++ b/modules/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arranger/schema",
-  "version": "1.0.35",
+  "version": "1.0.36",
   "description": "GraphQL Schema for Data Portals",
   "main": "dist/index.js",
   "publishConfig": {
@@ -24,8 +24,8 @@
     "graphql": "^14.0.2"
   },
   "dependencies": {
-    "@arranger/mapping-utils": "^1.0.35",
-    "@arranger/middleware": "^1.0.35",
+    "@arranger/mapping-utils": "^1.0.36",
+    "@arranger/middleware": "^1.0.36",
     "babel-polyfill": "^6.26.0",
     "elasticsearch": "^14.0.0",
     "graphql-middleware": "1.3.1",

--- a/modules/server/package.json
+++ b/modules/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@arranger/server",
-  "version": "1.0.35",
+  "version": "1.0.36",
   "description": "GraphQL Server",
   "main": "dist/index.js",
   "bin": {
@@ -27,10 +27,10 @@
   },
   "homepage": "https://github.com/overture-stack/arranger#readme",
   "dependencies": {
-    "@arranger/admin": "^1.0.35",
-    "@arranger/mapping-utils": "^1.0.35",
-    "@arranger/middleware": "^1.0.35",
-    "@arranger/schema": "^1.0.35",
+    "@arranger/admin": "^1.0.36",
+    "@arranger/mapping-utils": "^1.0.36",
+    "@arranger/middleware": "^1.0.36",
+    "@arranger/schema": "^1.0.36",
     "apollo-server-core": "1.3.2",
     "apollo-server-express": "^1.3.1",
     "babel-polyfill": "^6.26.0",


### PR DESCRIPTION
The range filter "clear" link used to reset the values of min and max fields to the original values, but it wasn't working anymore.

It is now fixed and the package was published to v1.0.36.