### PR TITLE
Set the base docker image version

### DIFF
--- a/server.Dockerfile
+++ b/server.Dockerfile
@@ -1,4 +1,4 @@
-FROM mhart/alpine-node:latest
+FROM mhart/alpine-node:13.13.0
 
 RUN apk add --no-cache curl
 


### PR DESCRIPTION
mhart/alpine-node image has been updated and the last version seems to be broken.