### PR TITLE
Add version to nginx image

### DIFF
--- a/ui.Dockerfile
+++ b/ui.Dockerfile
@@ -1,4 +1,4 @@
-FROM nginx
+FROM nginx:1.17.9
 
 RUN apt-get update -y && apt-get upgrade -y
 RUN apt-get install curl -y


### PR DESCRIPTION
This afternoon, they have updated the nginx image and a similar error to the one existent with the alpine image appears (I think that alpine is the base image for the Nginx version). Since there aren't more docker recipes, I hope everything should be fixed.