### PR TITLE
Fix/small release bugs

### DIFF
--- a/modules/components/src/Arranger/QuickSearch/QuickSearch.js
+++ b/modules/components/src/Arranger/QuickSearch/QuickSearch.js
@@ -103,6 +103,7 @@ const QuickSearch = ({
       <QuickSearchQuery
         {...props}
         {...{ primaryKeyField, quickSearchFields }}
+        searchLowercase={searchLowercase}
         searchTextDelimiters={searchTextDelimiters}
         searchText={value}
         render={({ results: searchResults, loading }) => (

--- a/modules/server/src/utils/getAllData.js
+++ b/modules/server/src/utils/getAllData.js
@@ -26,7 +26,6 @@ export default async ({
   const { esIndex, esType, extended } = await es
     .search({
       index: `arranger-projects-${projectId}`,
-      type: `arranger-projects-${projectId}`,
     })
     .then(toHits)
     .then(hits => hits.map(({ _source }) => _source))
@@ -71,7 +70,6 @@ export default async ({
         const hits = await es
           .search({
             index: esIndex,
-            type: esType,
             size: chunkSize,
             body: {
               sort: esSort,


### PR DESCRIPTION
- for case insensitive search, missed passing the property to the child
- for tsv download, need to remove the `type` property from es.search