### PR TITLE
add configurable nginx path to dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,6 +67,7 @@ ENV APP_GID=9999
 ENV APP_USER=node
 ENV APP_HOME=/app
 ENV PORT=3000
+ENV NGINX_CONF_PATH=/etc/nginx/nginx.conf
 
 COPY docker/ui/nginx.conf.template /etc/nginx/nginx.conf.template
 
@@ -84,9 +85,9 @@ COPY --from=builder2 /app $APP_HOME
 
 WORKDIR $APP_HOME
 
-USER $APP_UID
+USER $APP_USER
 
-CMD envsubst '$PORT,$REACT_APP_ARRANGER_ADMIN_ROOT' < /etc/nginx/nginx.conf.template > /etc/nginx/nginx.conf && exec nginx -g 'daemon off;'
+CMD envsubst '$PORT,$REACT_APP_ARRANGER_ADMIN_ROOT' < /etc/nginx/nginx.conf.template > $NGINX_CONF_PATH && exec nginx -c $NGINX_CONF_PATH -g 'daemon off;'
 
 #######################################################
 # Test


### PR DESCRIPTION
this is neccessary, since in some k8s environment, the disk is readonly. This allows us to define an volitile and writable directory in k8s (emptyDir), and then configure the container render the template to that directory, and nginx to read the config from the directory 