### PR TITLE
add track total hits in hit resolver + schema

### DIFF
--- a/modules/mapping-utils/src/createConnectionTypeDefs.js
+++ b/modules/mapping-utils/src/createConnectionTypeDefs.js
@@ -28,6 +28,7 @@ export default ({ type, fields = '', createStateTypeDefs = true }) => `
       first: Int
       last: Int
       searchAfter: JSON
+      trackTotalHits: Boolean
     ): ${type.name}Connection
 
     aggregations(

--- a/modules/mapping-utils/src/createConnectionTypeDefs.js
+++ b/modules/mapping-utils/src/createConnectionTypeDefs.js
@@ -28,7 +28,7 @@ export default ({ type, fields = '', createStateTypeDefs = true }) => `
       first: Int
       last: Int
       searchAfter: JSON
-      trackTotalHits: Boolean
+      trackTotalHits: Boolean = true
     ): ${type.name}Connection
 
     aggregations(

--- a/modules/mapping-utils/src/resolveHits.js
+++ b/modules/mapping-utils/src/resolveHits.js
@@ -149,7 +149,7 @@ export const hitsToEdges = ({
 
 export default ({ type, Parallel, getServerSideFilter }) => async (
   obj,
-  { first = 10, offset = 0, filters, score, sort, searchAfter },
+  { first = 10, offset = 0, filters, score, sort, search, trackTotalHits = true },
   { es },
   info,
 ) => {
@@ -209,6 +209,7 @@ export default ({ type, Parallel, getServerSideFilter }) => async (
     index: type.index,
     size: first,
     from: offset,
+    track_total_hits: trackTotalHits,
     _source: [
       ...((fields.edges && Object.keys(fields.edges.node || {})) || []),
       ...Object.values(copyToSourceFields),

--- a/modules/mapping-utils/src/resolveHits.js
+++ b/modules/mapping-utils/src/resolveHits.js
@@ -149,7 +149,7 @@ export const hitsToEdges = ({
 
 export default ({ type, Parallel, getServerSideFilter }) => async (
   obj,
-  { first = 10, offset = 0, filters, score, sort, search, trackTotalHits = true },
+  { first = 10, offset = 0, filters, score, sort, searchAfter, trackTotalHits = true },
   { es },
   info,
 ) => {


### PR DESCRIPTION
https://www.elastic.co/guide/en/elasticsearch/client/javascript-api/7.x/api-reference.html#_search

Add parameter for `track_total_hits`, defaulted to true