### PR TITLE
DataTable store row selections

### DIFF
--- a/modules/components/src/DataTable/DataTable.js
+++ b/modules/components/src/DataTable/DataTable.js
@@ -104,7 +104,7 @@ class DataTableWithToolbar extends React.Component {
       onSortedChange = () => {},
       alwaysSorted = [],
       initalSelectedTableRows,
-      keepSelectedOnPageChange = false, // If false, this will reset the selection to empty on reload even if sessionStorage is enabled. To keep selections after reload st this to true.
+      keepSelectedOnPageChange = false, // If false, this will reset the selection to empty on reload even if sessionStorage is enabled. To keep selections after reload set this to true.
       showFilterInput = true,
       filterInputPlaceholder,
       InputComponent,

--- a/modules/components/stories/table.js
+++ b/modules/components/stories/table.js
@@ -202,6 +202,9 @@ storiesOf('Table', module)
       fetchData={fetchDummyData}
       sessionStorage={true}
       storageKey="storybook"
+      // Note: keepSelectedOnPageChange doesn't work atm because the row IDs are regenerated on page reload.
+      //       Including this here as a reference that this needs to be toggled on to maintain storage between page loads
+      keepSelectedOnPageChange={true}
     />
   ))
   .add('Live Data Table', () => <EnhancedDataTable />);


### PR DESCRIPTION
Added more sessionStorage controlled functionality. Row selections in the DataTable will be stored in sessionStorage when changed and read in when the table is constructed. The existing storage methods now have slightly more generic methods to reduce the code repetititition.

Setting sessionStorage to true is sufficient to keep the selections while navigating through the app, but to make the selections persists over page loads, the data table also requires `keepSelectedOnPageChange={true}`. This is an old existing property that afaik wasn't previously doing anything. I kept this as it was just in case it had an existing use I am unaware of, and also since it was working as expected based on the property name.