### PR TITLE
add row selection filter for table exporters

### DIFF
--- a/modules/components/src/DataTable/DataTable.js
+++ b/modules/components/src/DataTable/DataTable.js
@@ -88,6 +88,7 @@ class DataTableWithToolbar extends React.Component {
       customHeaderContent = null,
       data = null,
       enableDropDownControls = false,
+      enableSelectedTableRowsExporterFilter = true,
       exporter,
       exportTSVFilename,
       exportTSVText,
@@ -127,6 +128,7 @@ class DataTableWithToolbar extends React.Component {
           defaultColumns={config.defaultColumns}
           downloadUrl={urlJoin(ARRANGER_API, projectId, 'download')}
           enableDropDownControls={enableDropDownControls}
+          enableSelectedTableRowsExporterFilter={enableSelectedTableRowsExporterFilter}
           exportTSVFilename={exportTSVFilename}
           exportTSVText={exportTSVText}
           exporter={exporter}

--- a/modules/components/src/DataTable/TableToolbar/TableToolbar.js
+++ b/modules/components/src/DataTable/TableToolbar/TableToolbar.js
@@ -53,6 +53,7 @@ const TableToolbar = ({
   defaultColumns,
   downloadUrl,
   enableDropDownControls = false,
+  enableSelectedTableRowsExporterFilter = true,
   exporter = null,
   exporterLabel = 'Download',
   exportTSVFilename = '',
@@ -85,20 +86,21 @@ const TableToolbar = ({
     columns,
   );
 
-  const downloadSqon = selectedTableRows.length
-    ? addInSQON(
-        {
-          op: 'and',
-          content: [
-            {
-              op: 'in',
-              content: { field: 'file_autocomplete', value: selectedTableRows },
-            },
-          ],
-        },
-        sqon,
-      )
-    : sqon;
+  const downloadSqon =
+    enableSelectedTableRowsExporterFilter && selectedTableRows.length
+      ? addInSQON(
+          {
+            op: 'and',
+            content: [
+              {
+                op: 'in',
+                content: { field: 'file_autocomplete', value: selectedTableRows },
+              },
+            ],
+          },
+          sqon,
+        )
+      : sqon;
 
   return (
     <div style={{ display: 'flex', flex: 'none', ...style }} className="tableToolbar">


### PR DESCRIPTION
@joneubank realised not all projects want to use the row selection as a filter, so this adds the option to disable that feature.