### PR TITLE
Allow alternate "labels" in toolbar dropdown

### DIFF
--- a/modules/components/src/DataTable/TableToolbar/TableToolbar.js
+++ b/modules/components/src/DataTable/TableToolbar/TableToolbar.js
@@ -23,18 +23,23 @@ const enhance = compose(
   }),
 );
 
-/** Advanced Implementation details (TODO move to TS) ******
+/** Advanced Implementation details ****** (TODO: move to TS)
  * This component allows library integrators to pass custom exporters (functionality to be run on the data, e.g. get JSON)
  * They can provide their own function (default is saveTSV) through `exporter`, and leverage other props like
  * `exportTSVText` and `exportTSVFilename` in order to customise the resulting button; or they can display multiple
  * options in a dropdown, by passing an array of objects with details like so:
  *
  * exporter = [{
- *   label: '',
- *   function: () => {},
- *   columns: [''],
- * }]
+ *   label: '' || () => </>,
+ *   fileName?: '',
+ *   function?: () => {},
+ *   columns?: [''],
+ * }, ...]
  *
+ * A label doesn't require an exporter function, and can be a React component (e.g. to display instructions, a divider, etc.)
+ * furthermore, if label is 'saveTSV', Arranger will use its internal TSV exporter.
+ * The function attribute accepts 'saveTSV' as well, in case you wish to use a custom label for it.
+ * When a fileName is given without a custom function, Arranger will also produce a TSV file.
  * Columns passed here override the ones being displayed in the table.
  * If columns is undefined/null, the exporter will use all the columns shown in the table.
  * However, if columns is an empty array, the exporter will use all the columns declared in the column-state config.
@@ -170,10 +175,12 @@ const TableToolbar = ({
         {multipleExporters ? ( // check if we're given more than one custom exporter
           <DropDown
             aria-label={`Download options`}
-            itemToString={(i) => i.exporterLabel}
+            itemToString={(i) =>
+              typeof i.exporterLabel === 'function' ? <i.exporterLabel /> : i.exporterLabel
+            }
             items={exporterArray}
             onChange={({ exporterColumns, exporterLabel, exporterFileName, exporterFunction }) =>
-              exporterFunction(
+              exporterFunction?.(
                 transformParams({
                   url: downloadUrl,
                   files: [

--- a/modules/components/src/DataTable/TableToolbar/helpers.js
+++ b/modules/components/src/DataTable/TableToolbar/helpers.js
@@ -24,23 +24,26 @@ const saveTSV = async ({ url, files = [], fileName, options = {} }) =>
 const exporterProcessor = (exporter, allowTSVExport, exportTSVText) => {
   const exporterArray =
     Array.isArray(exporter) &&
-    exporter.map((item) =>
-      [item, item?.function].some((fnName) => fnName === 'saveTSV') ||
-      (item.constructor === {}.constructor && !Object.keys(item).includes('function'))
-        ? {
-            exporterLabel: item?.label || exportTSVText,
-            exporterFunction: saveTSV,
-            exporterFileName: item?.fileName,
-            ...(item?.columns && Array.isArray(item.columns) && { exporterColumns: item?.columns }),
-          }
-        : Object.entries(item).reduce(
-            (exporterItem, [key, value]) => ({
-              ...exporterItem,
-              [`exporter${key[0].toUpperCase()}${key.slice(1)}`]: value,
-            }),
-            {},
-          ),
-    );
+    exporter
+      .filter((item) => item)
+      .map((item) =>
+        [item, item.function].some((fnName) => fnName === 'saveTSV') ||
+        (item.hasOwnProperty('fileName') && !item.hasOwnProperty('function'))
+          ? {
+              exporterLabel: item?.label || exportTSVText,
+              exporterFunction: saveTSV,
+              exporterFileName: item?.fileName,
+              ...(item?.columns &&
+                Array.isArray(item.columns) && { exporterColumns: item?.columns }),
+            }
+          : Object.entries(item).reduce(
+              (exporterItem, [key, value]) => ({
+                ...exporterItem,
+                [`exporter${key[0].toUpperCase()}${key.slice(1)}`]: value,
+              }),
+              {},
+            ),
+      );
 
   const multipleExporters = exporterArray && exporter.length > 1;
 

--- a/modules/components/src/DropDown/DropDown.css
+++ b/modules/components/src/DropDown/DropDown.css
@@ -22,7 +22,6 @@
   z-index: 100;
   border: 1px solid rgba(0, 0, 0, 0.05);
   box-sizing: border-box;
-  cursor: pointer;
   padding: 5px;
   top: 100%;
 }
@@ -39,8 +38,14 @@
 
 .dropDownContentElement {
   display: flex;
+  flex-wrap: wrap;
   justify-content: space-between;
   padding: 5px;
+  user-select: none;
+}
+
+.dropDownContentElement.clickable:hover {
+  cursor: pointer;
 }
 
 .multiSelectDropDownWrapper {

--- a/modules/components/src/DropDown/DropDown.js
+++ b/modules/components/src/DropDown/DropDown.js
@@ -76,32 +76,34 @@ class DropDown extends React.Component {
                   right: align === 'right' ? 0 : 'auto',
                   left: align === 'right' ? 'auto' : 0,
                 }}
+                {...(singleSelect && { onClick: this.handleToggleMenu })}
               >
-                {items.map((item, index) =>
-                  singleSelect ? (
+                {items.map((item, index) => {
+                  const { id, ...itemProps } = getItemProps({ item, index });
+                  const label = itemToString(item);
+                  const labelIsComponent = React.isValidElement(label);
+                  return (
                     <div
-                      className="dropDownContentElement"
-                      key={item.id || itemToString(item)}
-                      {...getItemProps({ item, index })}
+                      className={`dropDownContentElement${
+                        labelIsComponent ? ' custom' : ' clickable'
+                      }`}
+                      key={item.id || id}
+                      {...itemProps}
                     >
-                      {itemToString(item)}
+                      {label}
+                      {!(singleSelect || labelIsComponent) && (
+                        <input
+                          readOnly
+                          type="checkbox"
+                          checked={selectedItem.indexOf(item) > -1}
+                          aria-label={`Select column ${
+                            item.id || (typeof label === 'string' ? label : id)
+                          }`}
+                        />
+                      )}
                     </div>
-                  ) : (
-                    <div
-                      className="dropDownContentElement"
-                      key={item.id || itemToString(item)}
-                      {...getItemProps({ item, index })}
-                    >
-                      {itemToString(item)}
-                      <input
-                        readOnly
-                        type="checkbox"
-                        checked={selectedItem.indexOf(item) > -1}
-                        aria-label={`Select column ${item.id || itemToString(item)}`}
-                      />
-                    </div>
-                  ),
-                )}
+                  );
+                })}
               </div>
             )}
           </div>


### PR DESCRIPTION
So users can now render React components, and even text without an exporter.