### PR TITLE
🐛 Add support for non-text column `Header`s in MultiSelectDropdown

### DIFF
--- a/modules/components/src/DataTable/TableToolbar/TableToolbar.js
+++ b/modules/components/src/DataTable/TableToolbar/TableToolbar.js
@@ -152,7 +152,7 @@ const TableToolbar = ({
               itemSelectionLegend={`Select columns to display`}
               selectAllAriaLabel={`Select all columns`}
               resetToDefaultAriaLabel={`Reset to default columns`}
-              itemToString={(i) => i.Header}
+              itemToString={(i) => i.displayName || i.Header}
               items={canChangeShowColumns}
               defaultColumns={defaultColumns}
               onChange={(item) => {


### PR DESCRIPTION
After recent changes to HCMI from https://github.com/nci-hcmi-catalog/portal/pull/915 , it was noted that columns with their `Header` set as a function would render as a blank row in the column select dropdown. This is because the `itemToText` function expects the `Header` to be a string.

With this change, that function will use the optional `displayName` for a column instead (if available).

Commits:
🐛 Add support for non-text column `Header`s in MultiSelectDropdown
* Fixes a bug where column Headers set as functions would render as empty rows in the column selection dropdown