### PR TITLE
Use displayName instead of Header for data stream if available

### DIFF
--- a/modules/server/src/utils/dataToExportFormat.js
+++ b/modules/server/src/utils/dataToExportFormat.js
@@ -74,10 +74,10 @@ const getRows = (args) => {
 
 export const columnsToHeader = ({ columns, fileType = 'tsv' }) => {
   return fileType === 'tsv'
-    ? `${columns.map(({ Header }) => Header).join('\t')}`
+    ? `${columns.map(({ Header, displayName }) => (displayName ? displayName : Header)).join('\t')}`
     : fileType === 'json'
-    ? columns.reduce((output, { Header, accessor }) => {
-        output[[accessor]] = Header;
+    ? columns.reduce((output, { Header, displayName, accessor }) => {
+        output[[accessor]] = displayName ? displayName : Header;
         return output;
       }, {})
     : '';


### PR DESCRIPTION
Due to custom columns in search table, it is possible to not have a string value in the Header property for a column. In its place, the displayName value is used. This is a common pattern used with the columns object, adding it here to have header string values available for dataStream exports.