### PR TITLE
feat: No global aggregation wrapper if not required

### DIFF
--- a/modules/mapping-utils/src/createConnectionTypeDefs.js
+++ b/modules/mapping-utils/src/createConnectionTypeDefs.js
@@ -37,6 +37,7 @@ export default ({ type, fields = '', createStateTypeDefs = true }) => `
       include_missing: Boolean
       # Should term aggregations be affected by queries that contain filters on their field. For example if a query is filtering primary_site by Blood should the term aggregation on primary_site return all values or just Blood. Set to False for UIs that allow users to select multiple values of an aggregation.
       aggregations_filter_themselves: Boolean
+      no_global_aggregation: Boolean
     ): ${type.name}Aggregations
   }
 

--- a/modules/mapping-utils/src/resolveAggregations.js
+++ b/modules/mapping-utils/src/resolveAggregations.js
@@ -9,7 +9,13 @@ let toGraphqlField = (acc, [a, b]) => ({ ...acc, [a.replace(/\./g, '__')]: b });
 
 export default ({ type, getServerSideFilter }) => async (
   obj,
-  { offset = 0, filters, aggregations_filter_themselves, include_missing = true },
+  {
+    offset = 0,
+    filters,
+    aggregations_filter_themselves,
+    include_missing = true,
+    no_global_aggregation = false,
+  },
   context,
   info,
 ) => {
@@ -42,6 +48,7 @@ export default ({ type, getServerSideFilter }) => async (
     graphqlFields,
     nestedFields,
     aggregationsFilterThemselves: aggregations_filter_themselves,
+    no_global_aggregation,
   });
 
   const body = Object.keys(query || {}).length ? { query, aggs } : { aggs };

--- a/modules/middleware/src/buildAggregations/index.js
+++ b/modules/middleware/src/buildAggregations/index.js
@@ -61,11 +61,17 @@ function getNestedPathsInField({ field, nestedFields }) {
     .filter((p) => nestedFields.includes(p));
 }
 
-function wrapWithFilters({ field, query, aggregationsFilterThemselves, aggregation }) {
+function wrapWithFilters({
+  field,
+  query,
+  aggregationsFilterThemselves,
+  aggregation,
+  no_global_aggregation,
+}) {
   if (!aggregationsFilterThemselves) {
     const cleanedQuery = removeFieldFromQuery({ field, query });
     // TODO: better way to figure out that the field wasn't found
-    if (!isEqual(cleanedQuery || {}, query || {})) {
+    if (!no_global_aggregation && !isEqual(cleanedQuery || {}, query || {})) {
       return createGlobalAggregation({
         field,
         aggregation: createFilteredAggregation({
@@ -88,6 +94,7 @@ export default function ({
   nestedFields,
   aggregationsFilterThemselves,
   query,
+  no_global_aggregation,
 }) {
   const normalizedSqon = normalizeFilters(sqon);
   const nestedSqonFilters = getNestedSqonFilters({
@@ -117,6 +124,7 @@ export default function ({
         field,
         aggregation,
         aggregationsFilterThemselves,
+        no_global_aggregation,
       }),
     );
   }, {});

--- a/modules/middleware/src/constants.js
+++ b/modules/middleware/src/constants.js
@@ -14,8 +14,9 @@ export const LTE_OP = 'lte';
 export const BETWEEN_OP = 'between';
 
 // special values
-export const REGEX = '*';
+export const REGEX = 'regexp:';
 export const MISSING = '__missing__';
+export const EXISTS = '__exists__';
 export const SET_ID = 'set_id:';
 
 // sqon op aliases

--- a/modules/middleware/test/buildQuery/buildQuery.test.js
+++ b/modules/middleware/test/buildQuery/buildQuery.test.js
@@ -202,7 +202,6 @@ test('buildQuery "all" ops', () => {
   ];
   tests.forEach(({ input, output }) => {
     const actualOutput = buildQuery(input);
-    console.log('actualOutput: ', JSON.stringify(actualOutput));
     expect(actualOutput).toEqual(output);
   });
 });
@@ -933,6 +932,27 @@ test('buildQuery "not-in" op', () => {
       ],
     },
   };
+  const actualOutput = buildQuery(input);
+  expect(actualOutput).toEqual(output);
+});
+
+test('buildQuery should provide query to check if field exists', () => {
+  const input = {
+    nestedFields: [],
+    filters: {
+      op: 'and',
+      content: [
+        {
+          op: 'in',
+          content: {
+            field: 'some_field',
+            value: ['__exists__'],
+          },
+        },
+      ],
+    },
+  };
+  const output = { bool: { must: [{ exists: { boost: 0, field: 'some_field' } }] } };
   const actualOutput = buildQuery(input);
   expect(actualOutput).toEqual(output);
 });

--- a/modules/middleware/test/buildQuery/buildQueryWildcard.test.js
+++ b/modules/middleware/test/buildQuery/buildQueryWildcard.test.js
@@ -6,7 +6,7 @@ test('buildQuery wildcard nested', () => {
     {
       input: {
         nestedFields,
-        filters: { content: { field: 'case_id', value: ['006*'] }, op: 'in' },
+        filters: { content: { field: 'case_id', value: ['regexp:006.*'] }, op: 'in' },
       },
       output: { regexp: { case_id: '006.*' } },
     },
@@ -14,7 +14,7 @@ test('buildQuery wildcard nested', () => {
       input: {
         nestedFields,
         filters: {
-          content: [{ content: { field: 'case_id', value: ['006*'] }, op: 'in' }],
+          content: [{ content: { field: 'case_id', value: ['regexp:006.*'] }, op: 'in' }],
           op: 'and',
         },
       },
@@ -24,7 +24,7 @@ test('buildQuery wildcard nested', () => {
       input: {
         nestedFields,
         filters: {
-          content: { field: 'case_id', value: ['006*', 'v1'] },
+          content: { field: 'case_id', value: ['regexp:006.*', 'v1'] },
           op: 'in',
         },
       },
@@ -38,7 +38,7 @@ test('buildQuery wildcard nested', () => {
       input: {
         nestedFields,
         filters: {
-          content: [{ content: { field: 'case_id', value: ['006*', 'v1'] }, op: 'in' }],
+          content: [{ content: { field: 'case_id', value: ['regexp:006.*', 'v1'] }, op: 'in' }],
           op: 'and',
         },
       },
@@ -62,7 +62,7 @@ test('buildQuery wildcard nested', () => {
         nestedFields,
         filters: {
           content: [
-            { content: { field: 'case_id', value: ['006*', 'v1'] }, op: 'in' },
+            { content: { field: 'case_id', value: ['regexp:006.*', 'v1'] }, op: 'in' },
             {
               content: { field: 'project.primary_site', value: ['Brain'] },
               op: 'in',
@@ -91,7 +91,7 @@ test('buildQuery wildcard nested', () => {
       input: {
         nestedFields,
         filters: {
-          content: [{ content: { field: 'files.foo.name', value: 'cname*' }, op: '=' }],
+          content: [{ content: { field: 'files.foo.name', value: 'regexp:cname.*' }, op: '=' }],
           op: 'and',
         },
       },
@@ -131,7 +131,7 @@ test('buildQuery wildcard nested', () => {
             {
               content: {
                 field: 'files.foo.name',
-                value: ['*cname', 'cn*me', 'cname*'],
+                value: ['regexp:.*cname', 'regexp:cn.*me', 'regexp:cname.*'],
               },
               op: 'in',
             },
@@ -232,9 +232,9 @@ test('buildQuery wildcard nested', () => {
         nestedFields,
         filters: {
           content: [
-            { content: { field: 'files.foo.name1', value: '*cname' }, op: '=' },
-            { content: { field: 'files.foo.name2', value: 'cn*me' }, op: '=' },
-            { content: { field: 'files.foo.name3', value: 'cname*' }, op: '=' },
+            { content: { field: 'files.foo.name1', value: 'regexp:.*cname' }, op: '=' },
+            { content: { field: 'files.foo.name2', value: 'regexp:cn.*me' }, op: '=' },
+            { content: { field: 'files.foo.name3', value: 'regexp:cname.*' }, op: '=' },
           ],
           op: 'and',
         },


### PR DESCRIPTION
If some of these changes are already supported by arranger in its current form, please let me know. We'll make the necessary changes to the portal. Arranger is quite vast, its possible we did not understand a thing or 2...


### No Global Aggregation

[https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-global-aggregation.html](url)

In some queries, we do not want the buckets to be wrapped in the global aggregation, rather to **be** influenced by the search query.

```
{
   "observed_phenotype.name:global":{
      "global":{},
      "aggs":{
           "observed_phenotype.name:nested":{
               "nested":{
                  "path":"observed_phenotype"
               },
               "aggs":{
                     [--- rest of aggs ---]
               } 
          }
      }
  }
}
```
But we would rather this:
    
```
"observed_phenotype.name:nested":{
    "nested":{
          "path":"observed_phenotype"
      },
      "aggs":{
           [--- rest of aggs ---]
       } 
}
```

Maybe i'm not understanding something in arranger, but in `buildAggregation/index.js` the `createGlobalAggregation` function is always called. We have created a separate filter parameter to be able to specify that the global aggregation wrapper is not required (`no_global_aggregation`). 
     
        
### Exists query

Input sqon:
```
{
   "op":"in",
   "content":{
      "field":"tag.keyword",
      "value":[
         "__missing__"
      ]
   }
}
```
Currently in arranger if a value of `__missing__` is given, is will generate a query like this:

```
{
   "bool":{
      "must_not":[
         {
            "exists":{
               "boost":0,
               "field":"some_field"
            }
         }
      ]
   }
}
```
Returning all documents for which `some_field` does **not** exist. 

If we want all documents for which `some_field` **do** exists, it does not appear possible. In `getMissingFilter `function in `buildQuery/index/js` the value `isNot` is hardcoded to true.  If we enable to set `isNot` to false (as with the `__exists__` parameter), it the case the output of the function would be:
```
 {
    "exists":{
       "boost":0,
       "field":"some_field"
    }
 }
```
giving the result we would want.


### Regex Filter
[https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-regexp-query.html](url)
vs.
[https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-wildcard-query.html](url)

These changes were made in out arranger fork, however after verification we don't seem to use this functionality (regex filter) at all. Thus, all these changes could be ignored. I'm including this in here because the way its implemented in arranger does not appear to me to be correct. 

Currently Arranger does not really allow to truly pass a regex as input. Only more like a wildcard type of query. 
`esFilter: { regexp: { [field]: value.replace('*', '.*') } },` 
that get converted into a regex (.*)

but a wildcard query already exist trough passing `op: 'filter' ` in the input sqon, so why the regex filter would be required in the current state?

The following proposed changes enable to pass a regex as a value, but like i said, its not used in the portal.

