### PR TITLE
Response data & batching requests

### DIFF
--- a/modules/server/src/network/aggregations/index.ts
+++ b/modules/server/src/network/aggregations/index.ts
@@ -1,26 +1,27 @@
 import { SupportedAggregation, SUPPORTED_AGGREGATIONS } from '../common';
 import { Aggregations, NetworkAggregation, NumericAggregations, RemoteAggregation } from '../types';
 
-/**
- * Pick each field from network result aggregations and reduce into single aggregation
- *
- * @param networkResult
- * @param accumulator
- */
-
 type NetworkResult = {
 	[key: string]: RemoteAggregation;
 };
+
+type ResolveAggregationInput = {
+	networkResult: NetworkResult;
+	requestedAggregationFields: string[];
+	accumulator: any;
+};
+
+/**
+ * Resolves returned aggregations from network queries into single accumulated aggregation
+ *
+ * @param
+ * @returns number - Total bucket count for node
+ */
 export const resolveAggregations = ({
 	networkResult,
 	requestedAggregationFields,
 	accumulator,
-}: {
-	networkResult: NetworkResult;
-	requestedAggregationFields: string[];
-	accumulator: any;
-}) => {
-	// TODO: get documentName somewhere else, [0] isn't guaranteed
+}: ResolveAggregationInput): number => {
 	const documentName = Object.keys(networkResult)[0];
 
 	const nodeBucketCount = requestedAggregationFields.reduce((bucketCountAcc, fieldName) => {
@@ -34,9 +35,9 @@ export const resolveAggregations = ({
 			accumulatedFieldAggregations,
 		]);
 
-		// mutation - update accumulator
+		// mutation - updates accumulator
 		accumulator[fieldName] = resolvedAggregation;
-		// return { fieldName: fieldName, aggregation: resolvedAggregation };
+		// returns total bucket count for node
 		return bucketCountAcc + fieldBucketCount;
 	}, 0);
 
@@ -45,6 +46,7 @@ export const resolveAggregations = ({
 
 /**
  * Resolve aggregation based on aggregation type
+ *
  * @param type
  * @param aggregations
  */
@@ -63,43 +65,103 @@ export const resolveToNetworkAggregation = (
 };
 
 /**
- * Takes an array of the same aggregation type and computes the singular type
- * eg. NumericAggregation => NetworkNumericAggregation
+ * Mutation
+ * Updates existing or adds additional bucket to computed buckets
  *
- * Note for operations on Buckets -  the size of the array can be large (e.g. total bucket count), complicating lookups, etc.
+ * @param bucket - Bucket being processed
+ * @param computedBuckets - Existing buckets
+ */
+const updateComputedBuckets = (bucket, computedBuckets) => {
+	/*
+	 * Unable to use lookup key eg. buckets[key]
+	 * "buckets": [
+	 *  {
+	 *    "doc_count": 140,
+	 *    "key": "Dog"
+	 *   },
+	 */
+	const { key, doc_count } = bucket;
+	const existingBucketIndex = computedBuckets.findIndex((bucket) => bucket.key === key);
+	if (existingBucketIndex !== -1) {
+		const existingBucket = computedBuckets[existingBucketIndex];
+		if (existingBucket) {
+			// update existing bucket
+			computedBuckets[existingBucketIndex] = {
+				...existingBucket,
+				doc_count: existingBucket.doc_count + doc_count,
+			};
+		}
+	} else {
+		computedBuckets.push(bucket);
+	}
+};
+
+/**
+ * Resolves multiple aggregations into single
  *
  * @param aggregations
  * @returns
+ *
+ * @example
+ * #### Input
+ * ```javascript
+ *[
+ * {
+ *	bucket_count: 2,
+ *	buckets: [
+ *		{
+ *			key: 'Male',
+ *			doc_count: 15,
+ *		},
+ *		{
+ *			key: 'Female',
+ *			doc_count: 700,
+ *		},
+ *		{
+ *			key: 'Unknown',
+ *			doc_count: 5,
+ *		},
+ *	],
+ *	},
+ * {
+ * 	bucket_count: 2,
+ * 	buckets: [
+ * 		{
+ * 			key: 'Male',
+ * 			doc_count: 25,
+ * 		},
+ * 		{
+ * 			key: 'Female',
+ * 			doc_count: 100,
+ * 		},
+ * 	],
+ * }];
+ * ```
+ *
+ * #### Output
+ * ```javascript
+ * {
+ *  bucket_count: 3,
+ *  	buckets: [
+ *  		{
+ *  			key: 'Male',
+ *  			doc_count: 40,
+ *  		},
+ *  		{
+ *  			key: 'Female',
+ *  			doc_count: 800,
+ *  		},
+ *  		{
+ *  			key: 'Unknown',
+ *  			doc_count: 5,
+ *  		}]
+ *	}
+ * ```
  */
 export const resolveAggregation = (aggregations: Aggregations[]): NetworkAggregation => {
 	const resolvedAggregation = aggregations.reduce((resolvedAggregation, agg) => {
-		/*
-		 * Unable to use lookup key eg. buckets[key]
-		 * "buckets": [
-		 *  {
-		 *    "doc_count": 140,
-		 *    "key": "Dog"
-		 *   },
-		 */
 		const computedBuckets = resolvedAggregation.buckets;
-
-		// TODO: extract
-		agg.buckets.forEach((bucket) => {
-			const { key, doc_count } = bucket;
-			const existingBucketIndex = computedBuckets.findIndex((bucket) => bucket.key === key);
-			if (existingBucketIndex !== -1) {
-				const existingBucket = computedBuckets[existingBucketIndex];
-				if (existingBucket) {
-					// update existing bucket
-					computedBuckets[existingBucketIndex] = {
-						...existingBucket,
-						doc_count: existingBucket.doc_count + doc_count,
-					};
-				}
-			} else {
-				computedBuckets.push(bucket);
-			}
-		});
+		agg.buckets.forEach((bucket) => updateComputedBuckets(bucket, computedBuckets));
 		return { bucket_count: computedBuckets.length, buckets: computedBuckets };
 	});
 

--- a/modules/server/src/network/httpResponses.ts
+++ b/modules/server/src/network/httpResponses.ts
@@ -1,0 +1,53 @@
+// Success and Failure types
+export type Success<T> = { status: 'SUCCESS'; data: T };
+export type Failure<FailureStatus extends string, T = void> = {
+	status: FailureStatus;
+	message: string;
+	data: T;
+};
+
+/**
+ * Represents a response that on success will include data of type T,
+ * otherwise a message will be returned in place of the data explaining the failure with optional fallback data.
+ * The failure object has data type of void by default.
+ */
+export type Result<T, FailureStatus extends string, FailureData = void> =
+	| Success<T>
+	| Failure<FailureStatus, FailureData>;
+
+/* ******************* *
+   Convenience Methods 
+ * ******************* */
+
+/**
+ * Determines if the Result is a Success type by its status
+ * and returns the type predicate so TS can infer the Result as a Success
+ * @param result
+ * @returns {boolean} Whether the Result was a Success or not
+ */
+export function isSuccess<T, FailureStatus extends string, FailureData>(
+	result: Result<T, FailureStatus, FailureData>,
+): result is Success<T> {
+	return result.status === 'SUCCESS';
+}
+
+/**
+ * Create a successful response for a Result or Either type, with data of the success type
+ * @param {T} data
+ * @returns {Success<T>} `{status: 'SUCCESS', data}`
+ */
+export const success = <T>(data: T): Success<T> => ({ status: 'SUCCESS', data });
+
+/**
+ * Create a response indicating a failure with a status naming the reason and message describing the failure.
+ * @param {string} message
+ * @returns {Failure} `{status: string, message: string, data: undefined}`
+ */
+export const failure = <FailureStatus extends string>(
+	status: FailureStatus,
+	message: string,
+): Failure<FailureStatus, void> => ({
+	status,
+	message,
+	data: undefined,
+});

--- a/modules/server/src/network/index.ts
+++ b/modules/server/src/network/index.ts
@@ -47,9 +47,6 @@ const fetchRemoteSchema = async (
 			`Unexpected data in response object. Please verify the endpoint at ${graphqlUrl} is returning a valid GQL Schema.`,
 		);
 	} catch (error) {
-		/**
-		 * TODO: expand on error handling for instance of Axios error for example
-		 */
 		console.error(`Failed to retrieve schema from url: ${config.graphqlUrl}`);
 		return;
 	}

--- a/modules/server/src/network/queries/index.ts
+++ b/modules/server/src/network/queries/index.ts
@@ -56,7 +56,6 @@ export const aggregationsQuery = /* GraphQL */ `
 		buckets {
 			key
 			doc_count
-			key_as_string
 		}
 	}
 `;

--- a/modules/server/src/network/queries/index.ts
+++ b/modules/server/src/network/queries/index.ts
@@ -47,7 +47,6 @@ export const gqlAggregationTypeQuery = `#graphql
 	}
 `;
 
-// TODO: queries with variables eg. top_hits(_source:[String], size:Int): JSON
 export const aggregationsQuery = /* GraphQL */ `
 	#graphql
 	{

--- a/modules/server/src/network/resolvers/aggregations.ts
+++ b/modules/server/src/network/resolvers/aggregations.ts
@@ -54,7 +54,7 @@ export const aggregationPipeline = async (
 ) => {
 	/*
 	 * seed accumulator with the requested field keys
-	 * this will make it easier to add to because we can do key lookup instead of Array.find
+	 * this will make it easier to add to using key lookup instead of Array.find
 	 */
 	const emptyAggregation: NetworkAggregation = { bucket_count: 0, buckets: [] };
 	const aggregationAccumulator = requestedAggregationFields.reduce((accumulator, field) => {
@@ -71,8 +71,6 @@ export const aggregationPipeline = async (
 	>(async (query) => {
 		const name = query.url; // TODO: use readable name not url
 		const response = await fetchData(query);
-
-		// 	TODO	// instead of return response mergeField() // to clearly manipulate the accumlators
 
 		if (response && isSuccess(response)) {
 			const nodeBucketCount = resolveAggregations({
@@ -139,10 +137,10 @@ const createGqlFieldsString = (config: NetworkAggregationConfig, requestedAggreg
 };
 
 /**
- * Parse central query and build individual queries for remote connections based on available fields
+ * Create queries for remote nodes based on requested fields
  *
  * @param configs
- * @param info
+ * @param requestedAggregations
  * @returns
  */
 export const createNetworkQueries = (

--- a/modules/server/src/network/resolvers/index.ts
+++ b/modules/server/src/network/resolvers/index.ts
@@ -32,9 +32,13 @@ export const createResolvers = (configs: NetworkAggregationConfig[]) => {
 				const networkQueries = createNetworkQueries(configs, requestedAggregations);
 
 				// Query remote connections and aggregate results
-				const aggregationResults = await aggregationPipeline(networkQueries, requestedAggregations);
-
-				return aggregationResults;
+				const { aggregationResults, nodeInfo } = await aggregationPipeline(
+					networkQueries,
+					requestedAggregations,
+				);
+				const response = createResponse({ aggregationResults, nodeInfo });
+				console.log('resp', response);
+				return response;
 			},
 		},
 	};

--- a/modules/server/src/network/resolvers/index.ts
+++ b/modules/server/src/network/resolvers/index.ts
@@ -37,7 +37,7 @@ export const createResolvers = (configs: NetworkAggregationConfig[]) => {
 					requestedAggregations,
 				);
 				const response = createResponse({ aggregationResults, nodeInfo });
-				console.log('resp', response);
+
 				return response;
 			},
 		},

--- a/modules/server/src/network/resolvers/index.ts
+++ b/modules/server/src/network/resolvers/index.ts
@@ -1,7 +1,7 @@
 import { type GraphQLResolveInfo } from 'graphql';
 import { resolveAggregations } from '../aggregations';
 import { NetworkAggregationConfig, RemoteConnectionData } from '../types';
-import { getRootFields } from '../util';
+import { getRequestedFields } from '../util';
 import { createNetworkQueries, queryConnections } from './aggregations';
 import { resolveRemoteConnectionNodes } from './remoteConnections';
 import { createResponse } from './response';
@@ -13,6 +13,10 @@ type NetworkSearchRoot = {
 
 /**
  * Create GQL resolvers.
+ *
+ * It's important to have both remote connection data and aggregations under a single field
+ * as remote connection data is dependant on aggregations query
+ *
  * @param networkConfigsWithSchemas
  * @param networkFieldTypes
  * @returns
@@ -20,20 +24,20 @@ type NetworkSearchRoot = {
 export const createResolvers = (configs: NetworkAggregationConfig[]) => {
 	return {
 		Query: {
-			nodes: async () => await resolveRemoteConnectionNodes(configs),
-			aggregations: async (
+			network: async (
 				parent: NetworkSearchRoot,
 				args: {},
 				context: unknown,
 				info: GraphQLResolveInfo,
 			) => {
-				const rootQueryFields = getRootFields(info);
-				const networkQueries = createNetworkQueries(configs, rootQueryFields);
+				const { requestedAggregations } = getRequestedFields(info);
+				const networkQueries = createNetworkQueries(configs, requestedAggregations);
 				const networkResults = await queryConnections(networkQueries);
 
-				// Aggregate queried data
-				const resolvedResults = resolveAggregations(networkResults, rootQueryFields);
+				// Aggregate query results
+				const resolvedResults = resolveAggregations(networkResults, requestedAggregations);
 
+				// Create response
 				const response = createResponse(resolvedResults);
 				return response;
 			},

--- a/modules/server/src/network/resolvers/index.ts
+++ b/modules/server/src/network/resolvers/index.ts
@@ -4,6 +4,7 @@ import { NetworkAggregationConfig, RemoteConnectionData } from '../types';
 import { getRootFields } from '../util';
 import { createNetworkQueries, queryConnections } from './aggregations';
 import { resolveRemoteConnectionNodes } from './remoteConnections';
+import { createResponse } from './response';
 
 type NetworkSearchRoot = {
 	nodes: RemoteConnectionData[];
@@ -29,12 +30,11 @@ export const createResolvers = (configs: NetworkAggregationConfig[]) => {
 				const rootQueryFields = getRootFields(info);
 				const networkQueries = createNetworkQueries(configs, rootQueryFields);
 				const networkResults = await queryConnections(networkQueries);
+
 				// Aggregate queried data
 				const resolvedResults = resolveAggregations(networkResults, rootQueryFields);
-				// TODO: format to well defined response object createResponse(resolvedResults) jon success/failure, conform to schema shape etc
-				const response = resolvedResults.reduce((response, currentField) => {
-					return { ...response, ...{ [currentField.fieldName]: { ...currentField.aggregation } } };
-				}, {});
+
+				const response = createResponse(resolvedResults);
 				return response;
 			},
 		},

--- a/modules/server/src/network/resolvers/remoteConnections.ts
+++ b/modules/server/src/network/resolvers/remoteConnections.ts
@@ -2,6 +2,10 @@ import { ConnectionStatus, NetworkAggregationConfig, RemoteConnectionData } from
 import axios from 'axios';
 import urljoin from 'url-join';
 
+/*
+ * Setup config connections
+ */
+
 /**
  * Check the status of remote connections
  *
@@ -69,4 +73,15 @@ export const resolveRemoteConnectionNodes = async (
 			return remoteConnectionData;
 		}),
 	);
+};
+
+/*
+ * Querying from resolvers remote connections
+ */
+
+export type RemoteConnection = {
+	name: string;
+	count: number;
+	status: keyof typeof CONNECTION_STATUS;
+	errors: string;
 };

--- a/modules/server/src/network/resolvers/response.ts
+++ b/modules/server/src/network/resolvers/response.ts
@@ -1,5 +1,5 @@
 export const createResponse = (resolvedResults) => {
-	resolvedResults.reduce((response, currentField) => {
+	return resolvedResults.reduce((response, currentField) => {
 		return { ...response, ...{ [currentField.fieldName]: { ...currentField.aggregation } } };
 	}, {});
 };

--- a/modules/server/src/network/resolvers/response.ts
+++ b/modules/server/src/network/resolvers/response.ts
@@ -1,5 +1,5 @@
 /**
- * Format response object to match gql type
+ * Format response object to match gql type defs
  */
 export const createResponse = ({ aggregationResults, nodeInfo }) => {
 	return { remoteConnections: nodeInfo, aggregations: aggregationResults };

--- a/modules/server/src/network/resolvers/response.ts
+++ b/modules/server/src/network/resolvers/response.ts
@@ -1,10 +1,6 @@
-export const createResponse = (resolvedResults) => {
-	const data = resolvedResults.reduce((response, currentField) => {
-		return { ...response, ...{ [currentField.fieldName]: { ...currentField.aggregation } } };
-	}, {});
-	/*
-	 * Querying {network: {aggregations...}} so omit "network" in the returned object
-	 * GQL type and resolvers need to match
-	 */
-	return { aggregations: data };
+/**
+ * Format response object to match gql type
+ */
+export const createResponse = ({ aggregationResults, nodeInfo }) => {
+	return { remoteConnections: nodeInfo, aggregations: aggregationResults };
 };

--- a/modules/server/src/network/resolvers/response.ts
+++ b/modules/server/src/network/resolvers/response.ts
@@ -1,5 +1,10 @@
 export const createResponse = (resolvedResults) => {
-	return resolvedResults.reduce((response, currentField) => {
+	const data = resolvedResults.reduce((response, currentField) => {
 		return { ...response, ...{ [currentField.fieldName]: { ...currentField.aggregation } } };
 	}, {});
+	/*
+	 * Querying {network: {aggregations...}} so omit "network" in the returned object
+	 * GQL type and resolvers need to match
+	 */
+	return { aggregations: data };
 };

--- a/modules/server/src/network/resolvers/response.ts
+++ b/modules/server/src/network/resolvers/response.ts
@@ -1,0 +1,5 @@
+export const createResponse = (resolvedResults) => {
+	resolvedResults.reduce((response, currentField) => {
+		return { ...response, ...{ [currentField.fieldName]: { ...currentField.aggregation } } };
+	}, {});
+};

--- a/modules/server/src/network/typeDefs/aggregations.ts
+++ b/modules/server/src/network/typeDefs/aggregations.ts
@@ -1,4 +1,4 @@
-import { GraphQLObjectType, GraphQLSchema } from 'graphql';
+import { GraphQLObjectType, GraphQLSchema, GraphQLString } from 'graphql';
 import { SupportedNetworkFieldType } from '../types';
 import { singleToNetworkAggregationMap } from './networkAggregations';
 
@@ -34,18 +34,31 @@ export const createNetworkAggregationTypeDefs = (
 ) => {
 	const allFields = convertToGQLObjectType(networkFieldTypes);
 
-	const typeDefs = new GraphQLObjectType({
+	const aggregationsType = new GraphQLObjectType({
 		name: 'Aggregations',
 		fields: allFields,
+	});
+
+	const remoteConnectionsType = new GraphQLObjectType({
+		name: 'RemoteConnections',
+		fields: {
+			id: { type: GraphQLString },
+		},
+	});
+
+	const networkType = new GraphQLObjectType({
+		name: 'Network',
+		fields: {
+			remoteConnections: { type: remoteConnectionsType },
+			aggregations: { type: aggregationsType },
+		},
 	});
 
 	// correct object structure to merge with other types
 	const rootType = new GraphQLObjectType({
 		name: 'Query',
 		fields: {
-			aggregations: {
-				type: typeDefs,
-			},
+			network: { type: networkType },
 		},
 	});
 

--- a/modules/server/src/network/typeDefs/aggregations.ts
+++ b/modules/server/src/network/typeDefs/aggregations.ts
@@ -1,4 +1,4 @@
-import { GraphQLObjectType, GraphQLSchema, GraphQLString } from 'graphql';
+import { GraphQLInt, GraphQLList, GraphQLObjectType, GraphQLSchema, GraphQLString } from 'graphql';
 import { SupportedNetworkFieldType } from '../types';
 import { singleToNetworkAggregationMap } from './networkAggregations';
 
@@ -39,12 +39,17 @@ export const createNetworkAggregationTypeDefs = (
 		fields: allFields,
 	});
 
-	const remoteConnectionsType = new GraphQLObjectType({
-		name: 'RemoteConnections',
+	const remoteConnectionType = new GraphQLObjectType({
+		name: 'RemoteConnection',
 		fields: {
-			id: { type: GraphQLString },
+			name: { type: GraphQLString },
+			count: { type: GraphQLInt },
+			status: { type: GraphQLString },
+			errors: { type: GraphQLString },
 		},
 	});
+
+	const remoteConnectionsType = new GraphQLList(remoteConnectionType);
 
 	const networkType = new GraphQLObjectType({
 		name: 'Network',

--- a/modules/server/src/network/types.ts
+++ b/modules/server/src/network/types.ts
@@ -52,6 +52,8 @@ export type Aggregations = {
 
 export type NumericAggregations = {};
 
+export type RemoteAggregation = { [key: string]: Aggregations | NumericAggregations };
+
 export type NetworkAggregation = {
 	bucket_count: number;
 	buckets: Bucket[];

--- a/modules/server/src/network/util.ts
+++ b/modules/server/src/network/util.ts
@@ -31,13 +31,12 @@ export const fulfilledPromiseFilter = <Result>(result: unknown): result is Resul
 };
 
 /**
- * Returns only top level fields from a GQL request
+ * Returns requested fields
  *
  * @param info GQL request info object
- * @returns List of top level fields
+ * @returns
  */
-export const getRootFields = (info: GraphQLResolveInfo) => {
+export const getRequestedFields = (info: GraphQLResolveInfo) => {
 	const requestedFields = graphqlFields(info);
-	const fieldsAsList = Object.keys(requestedFields);
-	return fieldsAsList;
+	return { requestedAggregations: Object.keys(requestedFields.aggregations) };
 };


### PR DESCRIPTION
covers feedback from last demo
- batches resolving of aggregations as network node queries return instead of after all queries return
- changes gql response shape (including typedefs and resolver config changes)
- uses Jon's well tested success/failure code for network handling

There are some loose typings (any) to be addressed in future PR

aggregationPipeline mutates objects in order to batch results, comments clearly denote where this happens
open to suggestions for pure functional equivalent
