### PR TITLE
Individual node config query fields

### DIFF
--- a/modules/server/src/network/gql.ts
+++ b/modules/server/src/network/gql.ts
@@ -1,5 +1,6 @@
 import axios, { AxiosRequestConfig } from 'axios';
 import { ASTNode, print } from 'graphql';
+import { GQLFieldType } from './queries';
 
 /**
  * Creates a graphql query string with variables for use in a POST request
@@ -45,4 +46,9 @@ export const fetchGql = ({
 	};
 
 	return axios(axiosOptions);
+};
+
+export const normalizeGqlField = (gqlField: GQLFieldType): { name: string; type: string } => {
+	const fieldType = gqlField.type.name;
+	return { name: gqlField.name, type: fieldType };
 };

--- a/modules/server/src/network/index.ts
+++ b/modules/server/src/network/index.ts
@@ -18,15 +18,15 @@ export const createSchemaFromNetworkConfig = async ({
 }: {
 	networkConfigs: NetworkConfig[];
 }) => {
-	const networkFields = await fetchAllNodeAggregations({
+	const nodeConfig = await fetchAllNodeAggregations({
 		networkConfigs,
 	});
 
-	const networkFieldTypes = getAllFieldTypes(networkFields, SUPPORTED_AGGREGATIONS_LIST);
+	const networkFieldTypes = getAllFieldTypes(nodeConfig, SUPPORTED_AGGREGATIONS_LIST);
 
 	const typeDefs = createTypeDefs(networkFieldTypes);
 
-	const resolvers = createResolvers(networkConfigs);
+	const resolvers = createResolvers(nodeConfig);
 
 	const networkSchema = makeExecutableSchema({ typeDefs, resolvers });
 

--- a/modules/server/src/network/resolvers/index.ts
+++ b/modules/server/src/network/resolvers/index.ts
@@ -1,5 +1,7 @@
 import { type GraphQLResolveInfo } from 'graphql';
+import { NetworkFields } from '../setup/fields';
 import { NetworkConfig } from '../types/setup';
+import { NodeConfig } from '../types/types';
 import { resolveInfoToMap } from '../util';
 import { aggregationPipeline } from './aggregations';
 import { NetworkNode } from './networkNode';
@@ -20,7 +22,7 @@ export type NetworkSearchRoot = {
  * @param networkFieldTypes
  * @returns
  */
-export const createResolvers = (configs: NetworkConfig[]) => {
+export const createResolvers = (configs: NodeConfig[]) => {
 	return {
 		Query: {
 			network: async (

--- a/modules/server/src/network/resolvers/networkNode.ts
+++ b/modules/server/src/network/resolvers/networkNode.ts
@@ -12,4 +12,5 @@ export type NetworkNode = {
 	hits: number;
 	status: keyof typeof CONNECTION_STATUS;
 	errors: string;
+	aggregations: { name: string; type: string }[];
 };

--- a/modules/server/src/network/setup/fields.ts
+++ b/modules/server/src/network/setup/fields.ts
@@ -68,7 +68,7 @@ export const getAllFieldTypes = (
 
 		return { supportedAggregations, unsupportedAggregations };
 	});
-	console.log('n', nodeFieldTypes);
+
 	const allSupportedAggregations = nodeFieldTypes.flatMap(
 		(fieldType) => fieldType.supportedAggregations,
 	);

--- a/modules/server/src/network/setup/fields.ts
+++ b/modules/server/src/network/setup/fields.ts
@@ -2,6 +2,7 @@ import { SupportedAggregation } from '../common';
 import { GQLFieldType } from '../queries';
 import {
 	NetworkFieldType,
+	NodeConfig,
 	SupportedAggregations,
 	SupportedNetworkFieldType,
 	UnsupportedAggregations,
@@ -23,7 +24,7 @@ const isSupportedType = (
  * @returns { supportedAggregations: [], unsupportedAggregations: [] }
  */
 export const getFieldTypes = (
-	fields: GQLFieldType[],
+	fields: NodeConfig['aggregations'],
 	supportedAggregationsList: SupportedAggregation[],
 ) => {
 	const fieldTypes = fields.reduce(
@@ -34,17 +35,15 @@ export const getFieldTypes = (
 			},
 			field,
 		) => {
-			const fieldType = field.type.name;
-			const fieldObject = { name: field.name, type: fieldType };
-			if (isSupportedType(fieldObject, supportedAggregationsList)) {
+			if (isSupportedType(field, supportedAggregationsList)) {
 				return {
 					...aggregations,
-					supportedAggregations: aggregations.supportedAggregations.concat(fieldObject),
+					supportedAggregations: aggregations.supportedAggregations.concat(field),
 				};
 			} else {
 				return {
 					...aggregations,
-					unsupportedAggregations: aggregations.unsupportedAggregations.concat(fieldObject),
+					unsupportedAggregations: aggregations.unsupportedAggregations.concat(field),
 				};
 			}
 		},
@@ -58,18 +57,18 @@ export const getFieldTypes = (
 };
 
 export const getAllFieldTypes = (
-	networkFields: NetworkFields[],
+	nodeConfigs: NodeConfig[],
 	supportedTypes: SupportedAggregation[],
 ) => {
-	const nodeFieldTypes = networkFields.map((networkField) => {
+	const nodeFieldTypes = nodeConfigs.map((config) => {
 		const { supportedAggregations, unsupportedAggregations } = getFieldTypes(
-			networkField.fields,
+			config.aggregations,
 			supportedTypes,
 		);
 
 		return { supportedAggregations, unsupportedAggregations };
 	});
-
+	console.log('n', nodeFieldTypes);
 	const allSupportedAggregations = nodeFieldTypes.flatMap(
 		(fieldType) => fieldType.supportedAggregations,
 	);

--- a/modules/server/src/network/typeDefs/aggregations.ts
+++ b/modules/server/src/network/typeDefs/aggregations.ts
@@ -39,7 +39,7 @@ export const createNetworkAggregationTypeDefs = (
 		fields: allFields,
 	});
 
-	const aggList = new GraphQLObjectType({
+	const aggregationList = new GraphQLObjectType({
 		name: 'aggregations',
 		fields: {
 			name: { type: GraphQLString },
@@ -54,7 +54,7 @@ export const createNetworkAggregationTypeDefs = (
 			hits: { type: GraphQLInt },
 			status: { type: GraphQLString },
 			errors: { type: GraphQLString },
-			aggregations: { type: new GraphQLList(aggList) },
+			aggregations: { type: new GraphQLList(aggregationList) },
 		},
 	});
 

--- a/modules/server/src/network/typeDefs/aggregations.ts
+++ b/modules/server/src/network/typeDefs/aggregations.ts
@@ -39,6 +39,14 @@ export const createNetworkAggregationTypeDefs = (
 		fields: allFields,
 	});
 
+	const aggList = new GraphQLObjectType({
+		name: 'aggregations',
+		fields: {
+			name: { type: GraphQLString },
+			type: { type: GraphQLString },
+		},
+	});
+
 	const remoteConnectionType = new GraphQLObjectType({
 		name: 'RemoteConnection',
 		fields: {
@@ -46,6 +54,7 @@ export const createNetworkAggregationTypeDefs = (
 			hits: { type: GraphQLInt },
 			status: { type: GraphQLString },
 			errors: { type: GraphQLString },
+			aggregations: { type: new GraphQLList(aggList) },
 		},
 	});
 

--- a/modules/server/src/network/types/types.ts
+++ b/modules/server/src/network/types/types.ts
@@ -2,6 +2,7 @@ import { ObjectValues } from '@/utils/types';
 import { SupportedAggregation } from '../common';
 import { CONNECTION_STATUS } from '../resolvers/networkNode';
 import { Aggregations, Bucket, NumericAggregations } from './aggregations';
+import { NetworkConfig } from './setup';
 
 // environment config
 export type NetworkAggregationConfigInput = {
@@ -33,3 +34,5 @@ export type NetworkAggregation = {
 	bucket_count: number;
 	buckets: Bucket[];
 };
+
+export type NodeConfig = NetworkConfig & { aggregations: { name: string; type: string }[] };


### PR DESCRIPTION
- get available aggregations per node on api fetch response
- only send nodes queries with their individually available aggregations
- returns available aggregations with resolver info 