### PR TITLE
Fix Express middleware order

### DIFF
--- a/modules/server/src/app.js
+++ b/modules/server/src/app.js
@@ -11,10 +11,10 @@ export default async function (rootPath = '') {
 	global.__basedir = rootPath;
 
 	return arranger({ enableAdmin: ENV_CONFIG.ENABLE_ADMIN }).then((router) => {
-		app.use(router);
-
 		app.use(urlencoded({ extended: false, limit: '50mb' }));
 		app.use(json({ limit: '50mb' }));
+
+		app.use(router);
 
 		app.listen(ENV_CONFIG.PORT, async () => {
 			const message = `⚡️⚡️⚡️ Listening on port ${ENV_CONFIG.PORT} ⚡️⚡️⚡️`;


### PR DESCRIPTION
# Pull Request

## Description
This PR changes the middleware order in the Express app to ensure that Express `json()` and `urlencoded()` are executed before any routing logic. 

This change is required to ensure that Express middlewares controls the maximum request body size, property that is defined in:

```
app.use(urlencoded({ extended: false, limit: '50mb' }));
app.use(json({ limit: '50mb' }));
```

Fixes the issue:
- Getting a Response`413 request entity too large` calling the endpoint `POST http://arranger/download`  with a body larger than 100kb

## Type of change

Please choose only the relevant options and remove the others.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [X] Change tested locally by running Arranger and Portal and select a large items to download from the explorer.

## Checklist:

You do not need to fullfill all requirements of this checklist, select all that apply:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
