### PR TITLE
Moves handlers prop to top level

### DIFF
--- a/modules/charts/README.md
+++ b/modules/charts/README.md
@@ -44,3 +44,9 @@ For dev and debug purposes you can provide an ENV var of ARRANGER_CHARTS_DEBUG t
   </ChartsThemeProvider>
 
 ```
+
+## Common
+
+- handlers
+    - onClick: callback on clicking a segment of a chart
+        - returns full chart config object including label and value

--- a/modules/charts/src/components/charts/BarChart/BarChart.tsx
+++ b/modules/charts/src/components/charts/BarChart/BarChart.tsx
@@ -60,7 +60,10 @@ export const BarChart = ({ fieldName, handlers, theme }: BarChartProps) => {
 			isEmpty={isEmpty(gqlData)}
 			Chart={() => (
 				<ChartViewContainer>
-					<BarChartView data={gqlData} />
+					<BarChartView
+						data={gqlData}
+						handlers={handlers}
+					/>
 				</ChartViewContainer>
 			)}
 		/>

--- a/modules/charts/src/components/charts/BarChart/BarChartView.tsx
+++ b/modules/charts/src/components/charts/BarChart/BarChartView.tsx
@@ -4,14 +4,15 @@ import { useMemo } from 'react';
 
 import { useColorMap } from '#hooks/useColorMap';
 import { createColorMap } from '#theme/colors';
+import { BarChartProps } from './BarChart';
 import { arrangerToNivoBarChart } from './nivo/config';
 
-type BarChartViewProps = {
+interface BarChartViewProps {
 	data: any;
+	handlers: BarChartProps['handlers'];
 	theme: any;
 	colorMap: any;
-	onClick: any;
-};
+}
 
 const colorMapResolver = ({ chartData }) => {
 	const keys = chartData.map(({ key }: { key: string }) => key); // specfic chart color map code
@@ -29,14 +30,18 @@ const colorMapResolver = ({ chartData }) => {
  * @param props.onClick - Optional click handler for chart interactions
  * @returns JSX element with responsive bar chart
  */
-export const BarChartView = ({ data, theme, onClick }: BarChartViewProps) => {
+export const BarChartView = ({ data, handlers, theme }: BarChartViewProps) => {
 	// persistent color map
 	const { colorMap } = useColorMap({ chartData: data, resolver: colorMapResolver });
 
-	//return <pre>{JSON.stringify(data)}</pre>;
+	/**
+	 * TODO: improve "chart view" config/interface
+	 * right now it's a bit of a catch all config function
+	 * handlers currently only support onClick
+	 */
 	const resolvedTheme = useMemo(
-		() => arrangerToNivoBarChart({ theme, colorMap, onClick }),
-		[theme, colorMap, onClick],
+		() => arrangerToNivoBarChart({ theme, colorMap, onClick: handlers?.onClick }),
+		[theme, colorMap, handlers],
 	);
 
 	return (

--- a/modules/charts/src/hooks/useColorMap.tsx
+++ b/modules/charts/src/hooks/useColorMap.tsx
@@ -1,0 +1,17 @@
+import { useRef } from 'react';
+
+/**
+ * Custom hook that creates and maintains a persistent color map for chart data.
+ * Uses useRef to ensure color consistency across re-renders.
+ *
+ * @param { chartData } - Chart data to generate colors for
+ * @param { resolver } - Function that creates color map from chart data
+ * @returns Object containing the generated color map
+ */
+export const useColorMap = ({ chartData, resolver }) => {
+	const colorMap = useRef();
+	if (chartData && !colorMap.current) {
+		colorMap.current = resolver({ chartData });
+	}
+	return { colorMap: colorMap.current };
+};


### PR DESCRIPTION
Moves "handlers" props to top level instead of nested in "theme/config"
Doesn't alter underlying Nivo config resolution
Adds missing file that broke build