### PR TITLE
handle ranges for NumericAggregations more cleanly

### DIFF
--- a/modules/charts/src/components/Provider/Provider.tsx
+++ b/modules/charts/src/components/Provider/Provider.tsx
@@ -102,7 +102,7 @@ export const ChartsProvider = ({ children, debugMode }: ChartsProviderProps) => 
 
 	const deregisterChart = useCallback((fieldName) => {
 		logger.debug('Deregistering fieldName', fieldName);
-		removeQuery(fieldName);
+		fieldName !== '' && removeQuery(fieldName);
 	}, []);
 
 	const update = useCallback(({ fieldName, eventData }) => {

--- a/modules/charts/src/components/charts/BarChart/validate.tsx
+++ b/modules/charts/src/components/charts/BarChart/validate.tsx
@@ -14,7 +14,7 @@ export interface ValidationResult {}
 
 const validateAggregationsType = (queryProps): Result<ValidatedProps> => {
 	if (queryProps?.variables?.range) {
-		const message = 'Aggregations typename does not support options';
+		const message = `Field ${queryProps.fieldName} with typename "Aggregations" does not support "ranges" argument`;
 		logger.log(message);
 		return failure(message);
 	}
@@ -23,7 +23,7 @@ const validateAggregationsType = (queryProps): Result<ValidatedProps> => {
 
 const validateNumericAggregationsType = (queryProps): Result<ValidatedProps> => {
 	if (queryProps.variables.ranges === undefined) {
-		const message = 'NumericAggregations typename requires a provided "ranges" option';
+		const message = `Field ${queryProps.fieldName} with typename NumericAggregations requires a "ranges" argument`;
 		logger.log(message);
 		return failure(message);
 	}

--- a/modules/charts/src/hooks/useNetworkQuery.tsx
+++ b/modules/charts/src/hooks/useNetworkQuery.tsx
@@ -4,7 +4,7 @@ import { useEffect, useState } from 'react';
 const delay = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 export const useNetworkQuery = ({ query, apiFetcher, sqon }: { query: string; apiFetcher: any; sqon: {} }) => {
-	const [apiState, setApiState] = useState({ data: null, loading: true, error: false });
+	const [apiState, setApiState] = useState({ data: null, loading: false, error: false });
 
 	useEffect(() => {
 		if (!query) return;


### PR DESCRIPTION
Improve interface for handling "ranges" for NumericAggregations for Bar Chart

```tsx
// old
<BarChart
  fieldName="primary_diagnosis__age_at_diagnosis"
  query={{
    variables: {
      ranges: [
        { key: '< 18', to: 18 },
        { key: '18 - 65', from: 18, to: 66 },
        { key: '> 65', from: 66 },
       ],
      }}/>
 ```
 
 ```tsx
// new
<BarChart
  fieldName="primary_diagnosis__age_at_diagnosis"
  ranges: {[
        { key: '< 18', to: 18 },
        { key: '18 - 65', from: 18, to: 66 },
        { key: '> 65', from: 66 },
       ],
      }/>
 ```