### PR TITLE
Fix uncaught type error in config for non-SSR usage

### DIFF
--- a/modules/components/src/utils/config.js
+++ b/modules/components/src/utils/config.js
@@ -1,7 +1,8 @@
 function getValue(key, defaultValue) {
+	const processEnv = typeof process !== 'undefined' ? process.env : {};
 	return (
-		process.env[`STORYBOOK_${key}`] ||
-		process.env[`REACT_APP_${key}`] ||
+		processEnv[`STORYBOOK_${key}`] ||
+		processEnv[`REACT_APP_${key}`] ||
 		(typeof window !== 'undefined' && localStorage[key]) ||
 		defaultValue
 	);


### PR DESCRIPTION
Fixes uncaught type error for `process` variable.

@overture-stack/arranger-components can only work in frameworks that support SSR because `process` being available is assumed.

A simple check is added to make sure `process` is available, and if not, defaults to a safe empty object. This allows @overture-stack/arranger-components to work client side without SSR capabilities.