### PR TITLE
Remove AggsWrapper export from index.ts

### DIFF
--- a/modules/components/src/index.ts
+++ b/modules/components/src/index.ts
@@ -1,4 +1,4 @@
-export { Aggregations, AggregationsListDisplay, AggregationsList, AggsWrapper } from './aggregations/index.js';
+export { Aggregations, AggregationsListDisplay, AggregationsList } from './aggregations/index.js';
 export * from './Arranger/index.js';
 export {
 	DataContext as ArrangerDataContext,


### PR DESCRIPTION
Fix build issue from invalid import/export. AggsWrapper is not exported anywhere.