### PR TITLE
#1031: Add CSS classes for customizing tooltip text

### DIFF
--- a/modules/charts/package.json
+++ b/modules/charts/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@overture-stack/arranger-charts",
-	"version": "0.0.1-beta.12",
+	"version": "0.0.1-beta.13",
 	"main": ".dist/main.js",
 	"module": "./dist/main.js",
 	"types": "./dist/index.d.ts",

--- a/modules/charts/src/components/TooltipContainer.tsx
+++ b/modules/charts/src/components/TooltipContainer.tsx
@@ -15,7 +15,7 @@ export const TooltipContainer = ({ children }: PropsWithChildren<{}>) => {
 				borderRadius: ' 2px',
 				padding: '2px 4px',
 				color: 'white',
-				maxWidth: '100px',
+				maxWidth: '200px',
 				maxHeight: '100px',
 				background: '#4f546d',
 

--- a/modules/charts/src/components/charts/Tooltip.tsx
+++ b/modules/charts/src/components/charts/Tooltip.tsx
@@ -26,7 +26,13 @@ export const Tooltip = (tooltipData: Bar | SunburstSegment) => {
 		<TooltipContainer>
 			<div>
 				<div>{`${label}`}</div>
-				<div>{`${value}: Donor${value > 1 ? 's' : ''}`}</div>
+				<div>
+					<span>{value}</span>
+					<span className="tooltip-data-source-wrapper">
+						<span className="tooltip-data-source">: Donor</span>
+					</span>
+					<span>{value > 1 ? 's' : ''}</span>
+				</div>
 			</div>
 		</TooltipContainer>
 	);

--- a/package-lock.json
+++ b/package-lock.json
@@ -141,7 +141,7 @@
 		},
 		"modules/charts": {
 			"name": "@overture-stack/arranger-charts",
-			"version": "0.0.1-beta.9",
+			"version": "0.0.1-beta.11",
 			"dependencies": {
 				"@nivo/bar": "^0.88.0",
 				"@nivo/core": "^0.88.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -141,7 +141,7 @@
 		},
 		"modules/charts": {
 			"name": "@overture-stack/arranger-charts",
-			"version": "0.0.1-beta.11",
+			"version": "0.0.1-beta.13",
 			"dependencies": {
 				"@nivo/bar": "^0.88.0",
 				"@nivo/core": "^0.88.0",


### PR DESCRIPTION
## Summary

Adds HTML elements and CSS classes for customizing tooltip text, e.g. in Researcher UI in OHCRN.

Required for https://github.com/OHCRN/platform/issues/1769

## Issues
- #1031

## Description of Changes

### Charts
- Add `span` elements around the tooltip text we want to manipulate.
- Add CSS classes to these `span` elements so their CSS can be manipulated.
- Increase the tooltip's max width for better legibility.

Example SCSS from OHCRN's Researcher UI:

```scss
:global {
	.tooltip-data-source {
		display: none;
	}
	.tooltip-data-source-wrapper:after {
		display: inline-block;
		content: 'Participant';
		padding-left: 0.15rem;
	}
}

```

## Readiness Checklist

- [x] **Self Review**
  - I have performed a self review of code
  - I have run the application locally and manually tested the feature
  - I have checked all updates to correct typos and misspellings
- [x] **Formatting**
  - Code follows the project style guide
  - Autmated code formatters (ie. Prettier) have been run
- [x] **Local Testing**
  - Successfully built all packages locally
  - Successfully ran all test suites, all unit and integration tests pass
- [x] **Updated Tests**
  - Unit and integration tests have been added that describe the bug that was fixed or the features that were added
- [x] Documentation
  - All new environment variables added to `.env.schema` file and documented in the README
  - All changes to server HTTP endpoints have open-api documentation
  - All new functions exported from their module have TSDoc comment documentation