### PR TITLE
#1035, #1036: Single-folder vs Subfolder Detection 

### DIFF
--- a/apps/search-server/src/configs/index.ts
+++ b/apps/search-server/src/configs/index.ts
@@ -67,7 +67,6 @@ const buildCatalogsFromFolder = async ({
 			});
 
 			catalogsMap[catalogId] = aggregatedConfigs;
-
 		} catch (err) {
 			console.log(`Error loading catalog from ${dir.name}:`, (err as Error).message);
 		}

--- a/apps/search-server/src/configs/index.ts
+++ b/apps/search-server/src/configs/index.ts
@@ -1,12 +1,9 @@
+import fs from 'fs';
+import path from 'path';
 import { resolveCatalogId } from './catalogId.js';
 import aggregateConfigsFromEnv from './fromEnv/index.js';
 import getConfigFromFiles from './fromFiles/fileHandlers.js';
 import type { AllServerConfigs, CatalogsMap } from './types/index.js';
-
-// TODO: needs logic to support multiple catalogs
-// check if there's JSONs in this folder, then and do this following logic as is...
-// otherwise, if it finds folders, then read the jsons
-// therein as configs for one Arranger per folder.
 
 const buildCatalogsFromFolder = async ({
 	catalogConfigsPath,
@@ -18,24 +15,64 @@ const buildCatalogsFromFolder = async ({
 	currentDirectory: string;
 }): Promise<CatalogsMap> => {
 	const usedIds = new Set<string>();
+	const resolvedBase = path.resolve(currentDirectory, catalogConfigsPath);
+	const entries = await fs.promises.readdir(resolvedBase, { withFileTypes: true });
+	const hasJsonFiles = (entries: fs.Dirent[]) => entries.some((e) => e.isFile() && e.name.endsWith('.json'));
+	const getSubdirectories = (entries: fs.Dirent[]) => entries.filter((e) => e.isDirectory());
 
-	const [configsPath, aggregatedConfigs] = await getConfigFromFiles({
-		// FIXME: TypeScript doesn't believe this won't be undefined.
-		baseConfig: catalogs.fromEnv || {}, // WHY!?
-		catalogConfigsPath,
-		enableDebug,
-		currentDirectory,
-	});
+	if (hasJsonFiles(entries)) {
+		const [configsPath, aggregatedConfigs] = await getConfigFromFiles({
+			// FIXME: TypeScript doesn't believe this won't be undefined.
+			baseConfig: catalogs.fromEnv || {},
+			catalogConfigsPath,
+			enableDebug,
+			currentDirectory,
+		});
 
-	const catalogId = resolveCatalogId({
-		aggregatedConfigs,
-		configsPath,
-		usedIds,
-	});
+		const catalogId = resolveCatalogId({
+			aggregatedConfigs,
+			configsPath,
+			usedIds,
+		});
 
-	return {
-		[catalogId]: aggregatedConfigs,
-	};
+		return {
+			[catalogId]: aggregatedConfigs,
+		};
+	}
+
+	const subdirectories = getSubdirectories(entries);
+	const catalogsMap: CatalogsMap = {};
+
+	if (subdirectories.length === 0) {
+		console.log('No JSON files or subdirectories found. Using env defaults.');
+		return {};
+	}
+
+	for (const dir of subdirectories) {
+		const subPath = path.join(catalogConfigsPath, dir.name);
+
+		try {
+			const [configsPath, aggregatedConfigs] = await getConfigFromFiles({
+				// FIXME: TypeScript doesn't believe this won't be undefined.
+				baseConfig: catalogs.fromEnv || {},
+				catalogConfigsPath: subPath,
+				enableDebug,
+				currentDirectory,
+			});
+
+			const catalogId = resolveCatalogId({
+				aggregatedConfigs,
+				configsPath,
+				usedIds,
+			});
+
+			catalogsMap[catalogId] = aggregatedConfigs;
+
+		} catch (err) {
+			console.log(`Error loading catalog from ${dir.name}:`, (err as Error).message);
+		}
+	}
+	return catalogsMap;
 };
 
 const loadAllsConfigs = async ({ currentDirectory = '', ...externalConfigs }): Promise<AllServerConfigs> => {


### PR DESCRIPTION
Related to issue: #1035, #1036

## Summary

Extended buildCatalogsFromFolder function to support multi-catalog configuration by detecting whether the config path contains JSON files directly (single-catalog) or subdirectories (multi-catalog). 

## Description of Changes
 - Extended buildCatalogsFromFolder to detect JSON files vs subdirectories in the config path                                                                                                                                                                                
 - Single-catalog mode (backward-compatible): reads JSONs directly from the config folder                                                                                                                                                                                    
 - Multi-catalog mode: iterates subdirectories, each producing a separate catalog entry        

## Readiness Checklist

- [X] **Self Review**
  - I have performed a self review of code
  - I have run the application locally and manually tested the feature
  - I have checked all updates to correct typos and misspellings
- [X] **Formatting**
  - Code follows the project style guide
  - Automated code formatters (ie. Prettier) have been run
- [X] **Local Testing**
  - Successfully built all packages locally
  - Successfully ran all test suites, all unit and integration tests pass
- [X] **Updated Tests**
  - Unit and integration tests have been added that describe the bug that was fixed or the features that were added
- [X] Documentation
  - All new environment variables added to `.env.schema` file and documented in the README
  - All changes to server HTTP endpoints have open-api documentation
  - All new functions exported from their module have TSDoc comment documentation
