### PR TITLE
#1037:  Mount Per-Catalog Arranger Routers

### DIFF
--- a/apps/search-server/src/arrangerRoutes.ts
+++ b/apps/search-server/src/arrangerRoutes.ts
@@ -12,7 +12,7 @@ export default async ({
 	enableDebug: boolean;
 	esClient?: SearchClient;
 }): Promise<Router> => {
-const catalogEntries = Object.entries(catalogs);
+	const catalogEntries = Object.entries(catalogs);
 
 	if (catalogEntries.length === 0) {
 		throw new Error('No catalogs configured');

--- a/apps/search-server/src/arrangerRoutes.ts
+++ b/apps/search-server/src/arrangerRoutes.ts
@@ -13,12 +13,31 @@ export default async ({
 	esClient?: SearchClient;
 }): Promise<Router> => {
 	const catalogEntries = Object.entries(catalogs);
+	const catalogLength = catalogEntries.length;
 
-	if (catalogEntries.length === 0) {
+	if (catalogLength === 0) {
 		throw new Error('No catalogs configured');
 	}
 
 	const router = Router();
+	const firstCatalogEntry = catalogEntries[0];
+
+	if (catalogLength === 1 && firstCatalogEntry) {
+		const [catalogId, { getServerSideFilter, ...catalogConfigs }] = firstCatalogEntry;
+
+		const catalogRouter = await arrangerRouter({
+			configs: {
+				enableDebug,
+				...catalogConfigs,
+			},
+			esClient,
+			getServerSideFilter,
+		});
+
+		router.use(catalogRouter)
+		return router;
+	}
+
 	for (const [catalogId, { getServerSideFilter, ...catalogConfigs }] of catalogEntries) {
 		const catalogRouter = await arrangerRouter({
 			configs: {

--- a/apps/search-server/src/arrangerRoutes.ts
+++ b/apps/search-server/src/arrangerRoutes.ts
@@ -12,11 +12,14 @@ export default async ({
 	enableDebug: boolean;
 	esClient?: SearchClient;
 }): Promise<Router> => {
-	// TODO: extend this for multicatalog
-	const firstCatalogEntry = Object.entries(catalogs)[0];
-	if (firstCatalogEntry) {
-		const [catalogId, { getServerSideFilter, ...catalogConfigs }] = firstCatalogEntry;
+const catalogEntries = Object.entries(catalogs);
 
+	if (catalogEntries.length === 0) {
+		throw new Error('No catalogs configured');
+	}
+
+	const router = Router();
+	for (const [catalogId, { getServerSideFilter, ...catalogConfigs }] of catalogEntries) {
 		const catalogRouter = await arrangerRouter({
 			configs: {
 				enableDebug,
@@ -25,14 +28,7 @@ export default async ({
 			esClient,
 			getServerSideFilter,
 		});
-
-		const router = Router();
-		// TODO: this will be needed for multicatalog
-		// app.use(catalogId, catalogRouter); // for each catalogId
-		router.use(catalogRouter);
-
-		return router;
+		router.use(`/${catalogId}`, catalogRouter);
 	}
-
-	throw new Error('No catalogs configured');
+	return router;
 };

--- a/apps/search-server/src/configs/index.ts
+++ b/apps/search-server/src/configs/index.ts
@@ -67,7 +67,6 @@ const buildCatalogsFromFolder = async ({
 			});
 
 			catalogsMap[catalogId] = aggregatedConfigs;
-
 		} catch (err) {
 			console.log(`Error loading catalog from ${dir.name}:`, (err as Error).message);
 		}

--- a/apps/search-server/src/configs/index.ts
+++ b/apps/search-server/src/configs/index.ts
@@ -71,6 +71,20 @@ const buildCatalogsFromFolder = async ({
 			console.log(`Error loading catalog from ${dir.name}:`, (err as Error).message);
 		}
 	}
+
+	if (Object.keys(catalogsMap).length === 0) {
+		console.log('No catalogs loaded from subdirectories. Preserving env defaults.');
+		const catalogId = resolveCatalogId({
+			aggregatedConfigs: catalogs.fromEnv || {},
+			configsPath: resolvedBase,
+			usedIds,
+		});
+
+		return {
+			[catalogId]: catalogs.fromEnv || {},
+		};
+	}
+
 	return catalogsMap;
 };
 

--- a/apps/search-server/src/configs/index.ts
+++ b/apps/search-server/src/configs/index.ts
@@ -1,12 +1,9 @@
+import fs from 'fs';
+import path from 'path';
 import { resolveCatalogId } from './catalogId.js';
 import aggregateConfigsFromEnv from './fromEnv/index.js';
 import getConfigFromFiles from './fromFiles/fileHandlers.js';
 import type { AllServerConfigs, CatalogsMap } from './types/index.js';
-
-// TODO: needs logic to support multiple catalogs
-// check if there's JSONs in this folder, then and do this following logic as is...
-// otherwise, if it finds folders, then read the jsons
-// therein as configs for one Arranger per folder.
 
 const buildCatalogsFromFolder = async ({
 	catalogConfigsPath,
@@ -18,24 +15,64 @@ const buildCatalogsFromFolder = async ({
 	currentDirectory: string;
 }): Promise<CatalogsMap> => {
 	const usedIds = new Set<string>();
+	const resolvedBase = path.resolve(currentDirectory, catalogConfigsPath);
+	const entries = await fs.promises.readdir(resolvedBase, { withFileTypes: true });
+	const hasJsonFiles = (entries: fs.Dirent[]) => entries.some((e) => e.isFile() && e.name.endsWith('.json'));
+	const getSubdirectories = (entries: fs.Dirent[]) => entries.filter((e) => e.isDirectory());
 
-	const [configsPath, aggregatedConfigs] = await getConfigFromFiles({
-		// FIXME: TypeScript doesn't believe this won't be undefined.
-		baseConfig: catalogs.fromEnv || {}, // WHY!?
-		catalogConfigsPath,
-		enableDebug,
-		currentDirectory,
-	});
+	if (hasJsonFiles(entries)) {
+		const [configsPath, aggregatedConfigs] = await getConfigFromFiles({
+			// FIXME: TypeScript doesn't believe this won't be undefined.
+			baseConfig: catalogs.fromEnv || {},
+			catalogConfigsPath,
+			enableDebug,
+			currentDirectory,
+		});
 
-	const catalogId = resolveCatalogId({
-		aggregatedConfigs,
-		configsPath,
-		usedIds,
-	});
+		const catalogId = resolveCatalogId({
+			aggregatedConfigs,
+			configsPath,
+			usedIds,
+		});
 
-	return {
-		[catalogId]: aggregatedConfigs,
-	};
+		return {
+			[catalogId]: aggregatedConfigs,
+		};
+	}
+
+	const subdirectories = getSubdirectories(entries);
+	const catalogsMap: CatalogsMap = {};
+
+	if (subdirectories.length === 0) {
+		console.log('No JSON files or subdirectories found. Using env defaults.');
+		return {};
+	}
+
+	for (const dir of subdirectories) {
+		const subPath = path.join(catalogConfigsPath, dir.name);
+
+		try {
+			const [configsPath, aggregatedConfigs] = await getConfigFromFiles({
+				// FIXME: TypeScript doesn't believe this won't be undefined.
+				baseConfig: catalogs.fromEnv || {},
+				catalogConfigsPath: subPath,
+				enableDebug,
+				currentDirectory,
+			});
+
+			const catalogId = resolveCatalogId({
+				aggregatedConfigs,
+				configsPath,
+				usedIds,
+			});
+
+			catalogsMap[catalogId] = aggregatedConfigs;
+
+		} catch (err) {
+			console.log(`Error loading catalog from ${dir.name}:`, (err as Error).message);
+		}
+	}
+	return catalogsMap;
 };
 
 const loadAllsConfigs = async ({ currentDirectory = '', ...externalConfigs }): Promise<AllServerConfigs> => {

--- a/modules/graphql-router/src/router.ts
+++ b/modules/graphql-router/src/router.ts
@@ -23,10 +23,6 @@ export const createRequestPreprocessingMiddleware = ({
 	enforceAccessControl({ configs }),
 ];
 
-// TODO: for multicatalog, serverSideFilters may be also "per catalog"
-// i.e. each catalog may have their own, with no global filters
-// question: should global filters be allowed?
-
 const arrangerServer = async ({
 	configs: customConfigs = {},
 	configsSource = '',


### PR DESCRIPTION
Related to issue: #1034

## Summary

Refactors arrangerRoutes to iterate over each catalog and mount an arrangerRouter instance per catalog. 

## Description of Changes                                                                                                           
 - Replaced single-catalog logic with a loop that mounts all catalogs
 - Loops through all catalog entries, creating an arrangerRouter per catalog and mounting each at /<catalogId>
 
 ## Readiness Checklist
- [X] **Self Review**
  - I have performed a self review of code
  - I have run the application locally and manually tested the feature
  - I have checked all updates to correct typos and misspellings
- [X] **Formatting**
  - Code follows the project style guide
  - Automated code formatters (ie. Prettier) have been run
- [X] **Local Testing**
  - Successfully built all packages locally
  - Successfully ran all test suites, all unit and integration tests pass
- [X] **Updated Tests**
  - Unit and integration tests have been added that describe the bug that was fixed or the features that were added
- [X] **Documentation**
  - All new environment variables added to `.env.schema` file and documented in the README
  - All changes to server HTTP endpoints have open-api documentation
  - All new functions exported from their module have TSDoc comment documentation
