### PR TITLE
#1051: update Y axis offset for bar charts

### DIFF
--- a/modules/charts/package.json
+++ b/modules/charts/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@overture-stack/arranger-charts",
-	"version": "0.0.1-beta.12",
+	"version": "0.0.1-beta.15",
 	"main": ".dist/main.js",
 	"module": "./dist/main.js",
 	"types": "./dist/index.d.ts",

--- a/modules/charts/src/components/charts/Bar/nivo/config.tsx
+++ b/modules/charts/src/components/charts/Bar/nivo/config.tsx
@@ -32,7 +32,7 @@ export const arrangerToNivoBarChart = ({ theme, colorMap, onClick }) => {
 		axisLeft: {
 			legend: 'Axis-Left-Legend',
 			legendPosition: 'middle',
-			legendOffset: -70,
+			legendOffset: -74,
 
 			// tick
 			tickSize: 11,

--- a/modules/charts/src/components/charts/Bar/nivo/config.tsx
+++ b/modules/charts/src/components/charts/Bar/nivo/config.tsx
@@ -32,7 +32,7 @@ export const arrangerToNivoBarChart = ({ theme, colorMap, onClick }) => {
 		axisLeft: {
 			legend: 'Axis-Left-Legend',
 			legendPosition: 'middle',
-			legendOffset: -66,
+			legendOffset: -70,
 
 			// tick
 			tickSize: 11,

--- a/package-lock.json
+++ b/package-lock.json
@@ -141,7 +141,7 @@
 		},
 		"modules/charts": {
 			"name": "@overture-stack/arranger-charts",
-			"version": "0.0.1-beta.9",
+			"version": "0.0.1-beta.15",
 			"dependencies": {
 				"@nivo/bar": "^0.88.0",
 				"@nivo/core": "^0.88.0",


### PR DESCRIPTION
## Summary

Increases the left axis offset in bar charts, so that the axis title and values don't touch/overlap.

Required for https://github.com/OHCRN/platform/issues/1879

## Issues
- #1051

## Description of Changes

### Charts
- Increase left axis offset for bar charts

## Readiness Checklist

- [x] **Self Review**
  - I have performed a self review of code
  - I have run the application locally and manually tested the feature
  - I have checked all updates to correct typos and misspellings
- [x] **Formatting**
  - Code follows the project style guide
  - Autmated code formatters (ie. Prettier) have been run
- [x] **Local Testing**
  - Successfully built all packages locally
  - Successfully ran all test suites, all unit and integration tests pass
- [x] **Updated Tests**
  - Unit and integration tests have been added that describe the bug that was fixed or the features that were added
- [x] Documentation
  - All new environment variables added to `.env.schema` file and documented in the README
  - All changes to server HTTP endpoints have open-api documentation
  - All new functions exported from their module have TSDoc comment documentation
