### PR TITLE
charts: add top X of Y

### DIFF
--- a/modules/charts/src/components/charts/Bar/BarChart.tsx
+++ b/modules/charts/src/components/charts/Bar/BarChart.tsx
@@ -43,12 +43,12 @@ export interface BarChartProps {
  * @returns JSX element with complete bar chart or null if field validation fails
  */
 export const BarChart = ({
-	fieldName,
-	ranges,
-	handlers,
-	theme,
-	maxBars,
 	disableTopBarsCount = false,
+	fieldName,
+	handlers,
+	maxBars,
+	ranges,
+	theme,
 }: BarChartProps) => {
 	// ensure maxBars is provided
 	if (!maxBars) {

--- a/modules/charts/src/components/charts/Bar/BarChart.tsx
+++ b/modules/charts/src/components/charts/Bar/BarChart.tsx
@@ -7,6 +7,7 @@ import { ChartContainer } from '#components/ChartContainer';
 import { ChartRenderer } from '#components/ChartRenderer';
 import { useChartsContext } from '#components/Provider/Provider';
 import { logger } from '#logger';
+import TopChartItemsCount from '../TopChartItemsCount.tsx';
 import { validateQueryProps } from '../validate';
 import { BarChartView } from './View';
 
@@ -25,6 +26,7 @@ export interface BarChartProps {
 	ranges?: Ranges;
 	theme: { sortByKey?: string[] } & SupportedNivo;
 	handlers?: { onClick: (config: any) => void };
+	enableTopBarsCount?: boolean;
 }
 
 /**
@@ -38,7 +40,14 @@ export interface BarChartProps {
  * @param props.theme - Chart config mostly for Nivo
  * @returns JSX element with complete bar chart or null if field validation fails
  */
-export const BarChart = ({ fieldName, ranges, handlers, theme, maxBars }: BarChartProps) => {
+export const BarChart = ({
+	fieldName,
+	ranges,
+	handlers,
+	theme,
+	maxBars,
+	enableTopBarsCount = false,
+}: BarChartProps) => {
 	// ensure maxBars is provided
 	if (!maxBars) {
 		throw Error(`"maxBars" prop is required for ${fieldName} chart."`);
@@ -58,7 +67,11 @@ export const BarChart = ({ fieldName, ranges, handlers, theme, maxBars }: BarCha
 
 	useEffect(() => {
 		// validate and register
-		const result = validateQueryProps({ fieldName, variables, extendedMapping });
+		const result = validateQueryProps({
+			fieldName,
+			variables,
+			extendedMapping,
+		});
 
 		if (!validationResult.success) {
 			logger.log(validationResult.message);
@@ -74,13 +87,26 @@ export const BarChart = ({ fieldName, ranges, handlers, theme, maxBars }: BarCha
 
 	const { isLoading, isError, data: gqlData } = getChartData(fieldName);
 
+	// redundant chart emptiness check for typescript
+	const chartIsEmpty = isEmpty(gqlData);
+
+	const totalItems = gqlData?.length || 0;
+	// show TopChartItemsCount when there's more data than what is being displayed.
+	const showTopChartItemsCount = enableTopBarsCount && totalItems > maxBars;
+
 	return (
 		<ChartRenderer
 			isLoading={isLoading}
 			isError={isError || !validationResult.success}
-			isEmpty={isEmpty(gqlData)}
+			isEmpty={chartIsEmpty}
 			Chart={() => (
 				<ChartContainer>
+					{showTopChartItemsCount && (
+						<TopChartItemsCount
+							items={maxBars}
+							total={totalItems}
+						/>
+					)}
 					<BarChartView
 						data={gqlData}
 						handlers={handlers}

--- a/modules/charts/src/components/charts/Bar/BarChart.tsx
+++ b/modules/charts/src/components/charts/Bar/BarChart.tsx
@@ -26,7 +26,7 @@ export interface BarChartProps {
 	ranges?: Ranges;
 	theme: { sortByKey?: string[] } & SupportedNivo;
 	handlers?: { onClick: (config: any) => void };
-	enableTopBarsCount?: boolean;
+	disableTopBarsCount?: boolean;
 }
 
 /**
@@ -48,7 +48,7 @@ export const BarChart = ({
 	handlers,
 	theme,
 	maxBars,
-	enableTopBarsCount = false,
+	disableTopBarsCount = false,
 }: BarChartProps) => {
 	// ensure maxBars is provided
 	if (!maxBars) {
@@ -94,7 +94,7 @@ export const BarChart = ({
 
 	const totalItems = gqlData?.length || 0;
 	// show TopChartItemsCount when there's more data than what is being displayed.
-	const showTopChartItemsCount = enableTopBarsCount && totalItems > maxBars;
+	const showTopChartItemsCount = !disableTopBarsCount && totalItems > maxBars;
 
 	return (
 		<ChartRenderer

--- a/modules/charts/src/components/charts/Bar/BarChart.tsx
+++ b/modules/charts/src/components/charts/Bar/BarChart.tsx
@@ -38,6 +38,8 @@ export interface BarChartProps {
  * @param props.handlers - Event handlers for chart interactions
  * @param props.components - Custom components for fallback states
  * @param props.theme - Chart config mostly for Nivo
+ * @param props.maxBars = Required - determines how many bars to show.
+ *   If maxBars is greater than the amount of available data, TopChartItemsCount will be hidden.
  * @returns JSX element with complete bar chart or null if field validation fails
  */
 export const BarChart = ({

--- a/modules/charts/src/components/charts/Bar/BarChart.tsx
+++ b/modules/charts/src/components/charts/Bar/BarChart.tsx
@@ -70,9 +70,9 @@ export const BarChart = ({
 	useEffect(() => {
 		// validate and register
 		const result = validateQueryProps({
+			extendedMapping,
 			fieldName,
 			variables,
-			extendedMapping,
 		});
 
 		if (!validationResult.success) {

--- a/modules/charts/src/components/charts/TopChartItemsCount.tsx
+++ b/modules/charts/src/components/charts/TopChartItemsCount.tsx
@@ -1,0 +1,25 @@
+const TopChartItemsCount = ({ items, total }: { items: number; total: number }) => {
+	return (
+		<div
+			className="top-chart-bar-items-count"
+			style={{
+				position: 'absolute',
+				top: '0',
+				right: '0',
+				width: 'auto',
+				height: '1.375rem',
+				background: '#E5E7EB',
+				fontSize: '0.6875rem',
+				color: '#000000',
+				display: 'flex',
+				justifyContent: 'center',
+				alignItems: 'center',
+				padding: '0 0.5rem',
+				borderRadius: '0.25rem',
+				fontWeight: 'bold',
+			}}
+		>{`Top ${items} of ${total}`}</div>
+	);
+};
+
+export default TopChartItemsCount;


### PR DESCRIPTION
## Summary

Adds an optional label for bar charts that reads "Top X of Y" when there's more data available than what is being displayed.

## Issues
- [OHCRN #1898](https://github.com/OHCRN/platform/issues/1898)

## Readiness Checklist

- [x] **Self Review**
  - I have performed a self review of code
  - I have run the application locally and manually tested the feature
  - I have checked all updates to correct typos and misspellings
- [x] **Formatting**
  - Code follows the project style guide
  - Automated code formatters (ie. Prettier) have been run
- [x] **Local Testing**
  - Successfully built all packages locally
  - Successfully ran all test suites, all unit and integration tests pass
- [x] **Updated Tests**
  - Unit and integration tests have been added that describe the bug that was fixed or the features that were added
- [x] Documentation
  - All new environment variables added to `.env.schema` file and documented in the README
  - All changes to server HTTP endpoints have open-api documentation
  - All new functions exported from their module have TSDoc comment documentation
