### PR TITLE
feat: improve field “operators” layout in introspection, add catalogue descriptions

### DIFF
--- a/.dev/roadmap.md
+++ b/.dev/roadmap.md
@@ -141,11 +141,11 @@ _Note: `sqon-builder` git history can be preserved via `git subtree add` or `git
 
 _Priority: medium — cleanup work, doable independently._
 
-The logic for mapping ES field types to valid SQON operators currently exists in two separate places: a nuanced `getValidOperators()` in `apps/search-server/src/introspection/catalogDetails.ts`, and a simpler `getSqonFieldOperatorDetails()` in `modules/sqon`. These encode the same domain knowledge independently and will drift as operators or types are added.
+The logic for mapping ES field types to valid SQON operators currently exists in two separate places: `getValidFieldOperators()` in `modules/graphql-router/src/introspection/buildCatalogueIntrospection.ts`, and `getSqonFieldOperatorDetails()` in `modules/sqon`. These encode the same domain knowledge independently and will drift as operators or types are added.
 
-The goal is to make `modules/sqon` the single source of truth. `getSqonFieldOperatorDetails()` should be extended to carry the field-type classification detail currently encoded only in `catalogDetails.ts` (the ENUM_LIKE_TYPES / RANGE_TYPES distinction, boolean handling, etc.). `catalogDetails.ts` then becomes a thin projection over that data rather than a parallel implementation.
+The goal is to make `modules/sqon` the single source of truth. `getSqonFieldOperatorDetails()` should be extended to carry the field-type classification detail currently encoded only in `buildCatalogueIntrospection.ts` (the ENUM_LIKE_TYPES / RANGE_TYPES distinction, boolean handling, etc.). `buildCatalogueIntrospection.ts` then becomes a thin projection over that data rather than a parallel implementation.
 
-Done when: `catalogDetails.ts` no longer contains its own operator-applicability logic; `modules/sqon` exports all the rules needed for any consumer to determine valid operators for a given ES field type.
+Done when: `buildCatalogueIntrospection.ts` no longer contains its own operator-applicability logic; `modules/sqon` exports all the rules needed for any consumer to determine valid operators for a given ES field type.
 
 _Aligns with `sqon-builder` monorepo integration — if/when `sqon-builder` merges into `modules/sqon`, this work should be done first or alongside to avoid tripling the implementations._
 

--- a/.dev/sessions.md
+++ b/.dev/sessions.md
@@ -12,7 +12,18 @@ Newest first.
 
 - Fixed `/introspection/fields` correctness bug: each `arrangerRouter` instance now fetches the ES mapping once at startup, resolves live fields via `resolveCatalogueFields` (pure transform), and serves them from a local `GET /introspection` endpoint; `search-server` dispatches `/introspection/:catalogId` via URL rewriting; `catalogDetails.ts` deleted; logic lives in `graphql-router/src/introspection/buildCatalogueIntrospection.ts`
 - Moved `fetchMapping`, `getESAliases`, `checkESAlias`, and `getIndexMapping` from `mapping/utils/` and `graphqlRoutes.ts` into `searchClient/fetchMapping.ts` — all ES I/O now in one layer
-- Updated unit tests to match new shape
+- Added `description` as an optional catalogue config property (`configOptionalProperties.DESCRIPTION` in `modules/types`) — surfaces in both the root `/introspection` response and the per-catalogue `/introspection/:catalogId` response via conditional spread (key absent when not configured, not `undefined`)
+- Restructured `CatalogIntrospectionResponse`: removed `validOperators` from individual fields; added top-level `operators: Record<string, string[]>` keyed by field type; `buildFieldOperators()` in `buildCatalogueIntrospection.ts`
+- Updated unit tests to match new shape; added coverage for `description` present/absent and `operators` deduplication
+
+**Decisions:**
+- `operators` (not `typeOperators`) — cleaner, consistent with existing "operators" vocabulary in SQON introspection
+- `buildFieldOperators` (not `buildTypeOperators`) — "field operators" is the established naming family in `modules/sqon` (`SqonFieldOp`, `SqonFieldOperatorDetail`, `getSqonFieldOperatorDetails`)
+- `description` on per-catalogue response too (not just root listing) — complete data at the endpoint; LLM context optimization is the MCP layer's responsibility
+- `getValidOperators` → `modules/sqon` consolidation is out of scope: requires redesigning `applicableTo` data in `getSqonFieldOperatorDetails` (range types incorrectly include `filter`, `some-not-in`, `all` at present); separate roadmap item
+
+**Open threads:**
+- `getValidFieldOperators` → `modules/sqon` consolidation: follow-up when sqon consolidation roadmap item is picked up
 
 ---
 

--- a/.dev/tech-debt.md
+++ b/.dev/tech-debt.md
@@ -43,12 +43,12 @@ The preferred pattern is **(B)**. Mixing the two makes it harder to find tests, 
 **Fix:** Add a query or utility — either a new GraphQL field on the config endpoint or a standalone function in `modules/sqon` — that, given an Arranger index, returns each field name with its ES type and the set of valid SQON operators for that type. `getSqonFieldOperatorDetails()` already encodes the rules; it just needs to be composed with the field list.
 **Standalone:** yes — additive, no changes to existing query behaviour
 
-### `getValidOperators` in catalogDetails.ts and `getSqonFieldOperatorDetails` in modules/sqon are divergent implementations of the same rules
-**File:** `apps/search-server/src/introspection/catalogDetails.ts` — `getValidOperators()`; `modules/sqon/src/operators/index.ts` — `getSqonFieldOperatorDetails()`
+### `getValidFieldOperators` in graphql-router and `getSqonFieldOperatorDetails` in modules/sqon are divergent implementations of the same rules
+**File:** `modules/graphql-router/src/introspection/buildCatalogueIntrospection.ts` — `getValidFieldOperators()`; `modules/sqon/src/operators/index.ts` — `getSqonFieldOperatorDetails()`
 **Severity:** low (currently consistent in practice, but will drift)
 **Kind:** duplication / maintenance risk
-**Issue:** Two separate implementations encode which SQON operators are valid for which field types. `catalogDetails.ts` has a more nuanced classification (ENUM_LIKE_TYPES, RANGE_TYPES, fallback) while `modules/sqon` returns a flat list with `applicableTo: 'all'` for non-range operators. They're consistent today but maintained independently — any future operator addition requires updating both.
-**Fix:** Consolidate into `modules/sqon` as the single source of truth. Extend `getSqonFieldOperatorDetails()` to carry the same field-type classification detail that `catalogDetails.ts` currently encodes locally. `catalogDetails.ts` then becomes a thin projection over the module's data. See [roadmap: consolidate field-type-to-operator rules](roadmap.md#consolidate-field-type-to-operator-rules-into-modulessqon).
+**Issue:** Two separate implementations encode which SQON operators are valid for which field types. `buildCatalogueIntrospection.ts` has a more nuanced classification (ENUM_LIKE_TYPES, RANGE_TYPES, fallback) while `modules/sqon` returns a flat list with `applicableTo: 'all'` for non-range operators. They're consistent today but maintained independently — any future operator addition requires updating both.
+**Fix:** Consolidate into `modules/sqon` as the single source of truth. Extend `getSqonFieldOperatorDetails()` to carry the same field-type classification detail that `buildCatalogueIntrospection.ts` currently encodes locally. `buildCatalogueIntrospection.ts` then becomes a thin projection over the module's data. See [roadmap: consolidate field-type-to-operator rules](roadmap.md#consolidate-field-type-to-operator-rules-into-modulessqon).
 **Standalone:** yes — internal refactor, no change to API output
 
 ### SQON value schema does not accept boolean values

--- a/apps/mcp-server/src/mcp/tools.ts
+++ b/apps/mcp-server/src/mcp/tools.ts
@@ -10,7 +10,8 @@ export const buildFoundationTools = (): McpToolDefinition[] => [
 		name: 'get_sqon_schema',
 	},
 	{
-		description: 'Return field introspection for one catalog, including field names, field types, and valid operators.',
+		description:
+			'Return field introspection for one catalogue. `operators` maps each field type to its valid SQON operators. `fields` lists each field with its `type`, `displayName`, optional `unit`, and optional `description`.',
 		inputSchema: {
 			properties: {
 				catalogId: {

--- a/apps/search-server/src/introspection/introspection.test.ts
+++ b/apps/search-server/src/introspection/introspection.test.ts
@@ -72,4 +72,33 @@ suite('introspection tests', () => {
 		assert.ok(result.schema.$defs.SQON);
 		assert.ok(result.schema.$defs.Group);
 	});
+
+	test('includes description in root introspection when configured', () => {
+		const result = buildBaseIntrospection({
+			catalogs: {
+				models: {
+					documentType: 'model',
+					description: 'Clinical trial participant models.',
+				},
+			},
+		});
+
+		const entry = result.catalogs['models'];
+		assert.ok(entry !== undefined);
+		assert.equal(entry.description, 'Clinical trial participant models.');
+	});
+
+	test('omits description key from root introspection when not configured', () => {
+		const result = buildBaseIntrospection({
+			catalogs: {
+				models: {
+					documentType: 'model',
+				},
+			},
+		});
+
+		const entry = result.catalogs['models'];
+		assert.ok(entry !== undefined);
+		assert.ok(!('description' in entry));
+	});
 });

--- a/apps/search-server/src/introspection/serverDetails.ts
+++ b/apps/search-server/src/introspection/serverDetails.ts
@@ -20,6 +20,7 @@ const buildServerDetails = ({ catalogs }: { catalogs: CatalogsMap }): Introspect
 				return [
 					catalogId,
 					{
+						...(typedConfigs.description ? { description: typedConfigs.description } : {}),
 						documentType: typedConfigs.documentType || '',
 						paths: {
 							...(catalogCount === 1 ? { fields: '/introspection/fields' } : {}),

--- a/apps/search-server/src/introspection/types.ts
+++ b/apps/search-server/src/introspection/types.ts
@@ -3,6 +3,7 @@ export type IntrospectionResponse = {
 	catalogs: Record<
 		string,
 		{
+			description?: string;
 			documentType: string;
 			paths: {
 				fields?: string;
@@ -38,15 +39,16 @@ export type CatalogFieldIntrospection = {
 	displayName: string;
 	type: string;
 	unit?: string | null;
-	validOperators: string[];
 };
 
 export type CatalogIntrospectionResponse = {
 	catalogId: string;
+	description?: string;
 	documentType: string;
 	generatedAt: string;
 	meta: {
 		authFiltered: boolean;
 	};
+	operators: Record<string, string[]>;
 	fields: Record<string, CatalogFieldIntrospection>;
 };

--- a/apps/search-server/src/server.ts
+++ b/apps/search-server/src/server.ts
@@ -63,8 +63,8 @@ const arrangerServer = async ({ esClient, ...externalConfigs }: ExternalConfigs)
 
 		const { router: arrangerRouter, catalogueRouters } = await arrangerRoutes({ catalogs, enableDebug, esClient });
 
-		app.use('/', arrangerRouter);
 		app.use(createIntrospectionRoutes({ catalogs, catalogueRouters }));
+		app.use('/', arrangerRouter);
 
 		const server = app.listen(serverPort, () => {
 			const message = `⚡️⚡️⚡️ Listening on port ${serverPort} ⚡️⚡️⚡️`;

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -13,7 +13,7 @@ This guide will walk you through setting up a complete development environment, 
 
 ### Setting up supporting services
 
-We'll use the Overture quickstart service, a flexible Docker Compose setup, to spin up Maestro's complementary services.
+We'll use the Overture quickstart service, a flexible Docker Compose setup, to spin up Arranger's complementary services.
 
 1.  Clone the quickstart repository and navigate to its directory:
 

--- a/docs/usage/00-query-processing.md
+++ b/docs/usage/00-query-processing.md
@@ -15,7 +15,7 @@ SQON (Serializable Query Object Notation) is Overture's filter language for comm
 
 ## The Processing Flow
 
-The following example demonstrates the query proecessing pipeline:
+The following example demonstrates the query processing pipeline:
 
 ![Simple Filter](../assets/query-processing.png)
 

--- a/docs/usage/02-arranger-components.md
+++ b/docs/usage/02-arranger-components.md
@@ -10,7 +10,7 @@ Arranger offers its own front-end library of reusable components to facilitate q
 
 ## Configuration Files Overview
 
-As part of our latest work, in order to ensure Arranger v3.0 remains somewhat backawards-compatible and to facilitate the migration process from v2, we've established a temporary way to control the Server and Components' behaviour through files that centralize the way your indexed data is found and displayed.
+As part of our latest work, in order to ensure Arranger v3.0 remains somewhat backwards-compatible and to facilitate the migration process from v2, we've established a temporary way to control the Server and Components' behaviour through files that centralize the way your indexed data is found and displayed.
 This design will change in future versions (with corresponding documentation), to establish a better separation of concerns between front and back-end.
 
 These customizations can be divided into four files as follows:

--- a/docs/usage/03-sqon-in-detail.md
+++ b/docs/usage/03-sqon-in-detail.md
@@ -469,8 +469,77 @@ If you are generating SQON automatically, the safest defaults are:
 
 ## Related Endpoints
 
-When Arranger introspection is enabled, the following endpoints are useful together:
+When Arranger introspection is enabled, the following endpoints are useful together.
 
-- `/introspection/sqon` for the shared SQON JSON Schema and operator metadata
-- `/introspection/:catalogId` for catalog-specific field details
-- `/introspection/fields` as a single-catalog alias for field introspection
+### `GET /introspection`
+
+Lists all catalogues served by the instance. Each entry includes the catalogue's document type, its GraphQL and introspection paths, and an optional `description` when configured.
+
+```json
+{
+  "catalogCount": 1,
+  "mode": "single",
+  "sqonSchemaPath": "/introspection/sqon",
+  "catalogs": {
+    "participants": {
+      "description": "Clinical trial participant records.",
+      "documentType": "participant",
+      "paths": {
+        "fields": "/introspection/fields",
+        "graphql": "/graphql",
+        "introspection": "/introspection/participants"
+      }
+    }
+  }
+}
+```
+
+`description` is omitted when not set in the catalogue config. `paths.fields` is only present in single-catalogue mode.
+
+---
+
+### `GET /introspection/:catalogId`
+
+Returns field-level details for one catalogue. Use this to understand what fields exist, their types, and which SQON operators apply to each type.
+
+```json
+{
+  "catalogId": "participants",
+  "description": "Clinical trial participant records.",
+  "documentType": "participant",
+  "generatedAt": "2026-05-27T00:00:00.000Z",
+  "meta": { "authFiltered": false },
+  "operators": {
+    "keyword": ["in", "not-in", "some-not-in", "all", "filter"],
+    "long":    ["in", "not-in", "gt", "gte", "lt", "lte", "between"],
+    "date":    ["in", "not-in", "gt", "gte", "lt", "lte", "between"]
+  },
+  "fields": {
+    "participant_id": {
+      "displayName": "Participant ID",
+      "type": "keyword"
+    },
+    "age_at_diagnosis": {
+      "displayName": "Age at Diagnosis",
+      "type": "long",
+      "unit": "year"
+    },
+    "diagnosis_date": {
+      "displayName": "Diagnosis Date",
+      "type": "date"
+    }
+  }
+}
+```
+
+**`operators`** groups valid SQON operators by field type. To find which operators apply to a field, look up `operators[field.type]`. Only the types actually present in the catalogue's fields appear here.
+
+**`fields`** lists each field with its `displayName`, `type`, and optional `unit`. The `description` key is omitted when not configured.
+
+In single-catalogue mode, `/introspection/fields` is an alias for this endpoint.
+
+---
+
+### `GET /introspection/sqon`
+
+Returns the SQON JSON Schema and operator metadata shared across all catalogues — combination operators (`and`, `or`, `not`), field operators with value types and applicability, and accepted aliases. Use this to validate or describe SQON structure independently of any catalogue's field set.

--- a/modules/graphql-router/src/introspection/buildCatalogueIntrospection.test.ts
+++ b/modules/graphql-router/src/introspection/buildCatalogueIntrospection.test.ts
@@ -92,7 +92,28 @@ suite('buildCatalogueIntrospectionBody', () => {
 		assert.equal(result.meta.authFiltered, false);
 	});
 
-	test('builds fields with correct displayName, type, unit, and validOperators', () => {
+	test('includes description when provided', () => {
+		const result = buildCatalogueIntrospectionBody({
+			catalogId: 'models',
+			description: 'Clinical trial participant models.',
+			documentType: 'model',
+			resolvedFields: [],
+		});
+
+		assert.equal(result.description, 'Clinical trial participant models.');
+	});
+
+	test('omits description key when not provided', () => {
+		const result = buildCatalogueIntrospectionBody({
+			catalogId: 'models',
+			documentType: 'model',
+			resolvedFields: [],
+		});
+
+		assert.ok(!('description' in result));
+	});
+
+	test('builds fields with correct displayName, type, and unit', () => {
 		const result = buildCatalogueIntrospectionBody({
 			catalogId: 'models',
 			documentType: 'model',
@@ -103,39 +124,44 @@ suite('buildCatalogueIntrospectionBody', () => {
 			displayName: 'Analysis State',
 			type: 'keyword',
 			unit: null,
-			validOperators: ['in', 'not-in', 'some-not-in', 'all', 'filter'],
 		});
 
 		assert.deepEqual(result.fields['donor.age'], {
 			displayName: 'Donor Age',
 			type: 'long',
 			unit: 'year',
-			validOperators: ['in', 'not-in', 'gt', 'gte', 'lt', 'lte', 'between'],
 		});
 	});
 
-	test('assigns range operators to date fields', () => {
+	test('builds operators keyed by field type', () => {
 		const result = buildCatalogueIntrospectionBody({
 			catalogId: 'models',
 			documentType: 'model',
 			resolvedFields: RESOLVED_FIELDS,
 		});
 
-		assert.deepEqual(result.fields['collection.date']?.validOperators, [
-			'in', 'not-in', 'gt', 'gte', 'lt', 'lte', 'between',
-		]);
+		assert.deepEqual(result.operators['keyword'], ['in', 'not-in', 'some-not-in', 'all', 'filter']);
+		assert.deepEqual(result.operators['long'], ['in', 'not-in', 'gt', 'gte', 'lt', 'lte', 'between']);
 	});
 
-	test('assigns enum-like operators to boolean fields', () => {
+	test('assigns range operators to date fields in operators map', () => {
 		const result = buildCatalogueIntrospectionBody({
 			catalogId: 'models',
 			documentType: 'model',
 			resolvedFields: RESOLVED_FIELDS,
 		});
 
-		assert.deepEqual(result.fields['is_published']?.validOperators, [
-			'in', 'not-in', 'some-not-in', 'all', 'filter',
-		]);
+		assert.deepEqual(result.operators['date'], ['in', 'not-in', 'gt', 'gte', 'lt', 'lte', 'between']);
+	});
+
+	test('assigns enum-like operators to boolean fields in operators map', () => {
+		const result = buildCatalogueIntrospectionBody({
+			catalogId: 'models',
+			documentType: 'model',
+			resolvedFields: RESOLVED_FIELDS,
+		});
+
+		assert.deepEqual(result.operators['boolean'], ['in', 'not-in', 'some-not-in', 'all', 'filter']);
 	});
 
 	test('includes fields that exist only in the resolved (live) mapping', () => {
@@ -182,6 +208,7 @@ suite('buildCatalogueIntrospectionBody', () => {
 		});
 
 		assert.deepEqual(result.fields, {});
+		assert.deepEqual(result.operators, {});
 	});
 
 	test('falls back to displayType when type is absent', () => {
@@ -206,8 +233,20 @@ suite('buildCatalogueIntrospectionBody', () => {
 		});
 
 		assert.equal(result.fields['display_only']?.type, 'long');
-		assert.deepEqual(result.fields['display_only']?.validOperators, [
-			'in', 'not-in', 'gt', 'gte', 'lt', 'lte', 'between',
-		]);
+		assert.deepEqual(result.operators['long'], ['in', 'not-in', 'gt', 'gte', 'lt', 'lte', 'between']);
+	});
+
+	test('deduplicates operator entries when multiple fields share a type', () => {
+		const result = buildCatalogueIntrospectionBody({
+			catalogId: 'models',
+			documentType: 'model',
+			resolvedFields: [
+				{ ...RESOLVED_FIELDS[0], fieldName: 'field_a' },
+				{ ...RESOLVED_FIELDS[0], fieldName: 'field_b' },
+			],
+		});
+
+		assert.equal(Object.keys(result.operators).length, 1);
+		assert.ok('keyword' in result.operators);
 	});
 });

--- a/modules/graphql-router/src/introspection/buildCatalogueIntrospection.ts
+++ b/modules/graphql-router/src/introspection/buildCatalogueIntrospection.ts
@@ -24,38 +24,46 @@ const buildFields = (resolvedFields: ExtendedConfigs[]) =>
 	Object.fromEntries(
 		resolvedFields
 			.filter((field) => !!field.fieldName)
-			.map((field) => {
-				const fieldType = getFieldType(field);
-				return [
-					field.fieldName,
-					{
-						displayName: field.displayName || field.fieldName,
-						type: fieldType,
-						...(field.unit !== undefined ? { unit: field.unit } : {}),
-						validOperators: getValidFieldOperators(fieldType),
-					},
-				];
-			}),
+			.map((field) => [
+				field.fieldName,
+				{
+					displayName: field.displayName || field.fieldName,
+					type: getFieldType(field),
+					...(field.unit !== undefined ? { unit: field.unit } : {}),
+				},
+			]),
 	);
 
+const buildFieldOperators = (resolvedFields: ExtendedConfigs[]): Record<string, string[]> => {
+	const types = [
+		...new Set(
+			resolvedFields.filter((field) => !!field.fieldName).map((field) => getFieldType(field)),
+		),
+	];
+	return Object.fromEntries(types.map((type) => [type, getValidFieldOperators(type)]));
+};
+
 /**
- * Builds the catalogue field introspection response body from a live-resolved
- * field list. Response shape is intentionally identical to what the old
- * `buildCatalogDetails` in search-server produced — the `field-operators` branch
- * will restructure this shape when it rebases on top of this change.
+ * Builds the catalogue field introspection response body from a live-resolved field list.
+ * `operators` is keyed by field type — clients can look up valid operators for a given type
+ * without inspecting each field individually. `description` is included only when provided.
  */
 export const buildCatalogueIntrospectionBody = ({
 	catalogId,
+	description,
 	documentType,
 	resolvedFields,
 }: {
 	catalogId: string;
+	description?: string;
 	documentType: string;
 	resolvedFields: ExtendedConfigs[];
 }) => ({
 	catalogId,
+	...(description ? { description } : {}),
 	documentType,
 	fields: buildFields(resolvedFields),
+	operators: buildFieldOperators(resolvedFields),
 	generatedAt: new Date().toISOString(),
 	meta: { authFiltered: false as const },
 });

--- a/modules/graphql-router/src/router.ts
+++ b/modules/graphql-router/src/router.ts
@@ -89,6 +89,7 @@ const arrangerRouter = async <Context extends ArrangerBaseContext>({
 
 		const introspectionBody = buildCatalogueIntrospectionBody({
 			catalogId: configs[configOptionalProperties.CATALOG_ID] ?? '',
+			description: configs[configOptionalProperties.DESCRIPTION],
 			documentType: configs[configRootProperties.DOCUMENT_TYPE] ?? '',
 			resolvedFields,
 		});

--- a/modules/types/src/configs/constants.ts
+++ b/modules/types/src/configs/constants.ts
@@ -35,6 +35,7 @@ export const featureFlagDefaults = Object.values(configFeatureFlagProperties).re
 
 export const configOptionalProperties = {
 	CATALOG_ID,
+	DESCRIPTION: 'description',
 	ES_HOST: 'esHost',
 	DOWNLOADS: 'downloads',
 	EXTENDED: 'extended',

--- a/modules/types/src/configs/index.ts
+++ b/modules/types/src/configs/index.ts
@@ -173,6 +173,7 @@ export type ConfigsObject<Context> = {
 	AllFeatureFlagConfigs & {
 		getServerSideFilter: GetServerSideFilterFn<Context>;
 		[configOptionalProperties.CATALOG_ID]: string;
+		[configOptionalProperties.DESCRIPTION]: string;
 		[configOptionalProperties.ES_HOST]: string;
 		[configOptionalProperties.GRAPHQL_MAX_ALIASES]: number;
 		[configOptionalProperties.GRAPHQL_MAX_DEPTH]: number;


### PR DESCRIPTION
## Summary

In order to reduce LLM context bloat, we're abstracting the field operators in the introspection/fields endpoint; and we're adding catalogue descriptions to help the LLM pick and choose relevant datasets as needed.

## Readiness Checklist

- [x] **Self Review**
  - I have performed a self review of code
  - I have run the application locally and manually tested the feature
  - I have checked all updates to correct typos and misspellings
- [x] **Formatting**
  - Code follows the project style guide
  - Autmated code formatters (ie. Prettier) have been run
- [x] **Local Testing**
  - Successfully built all packages locally
  - Successfully ran all test suites, all unit and integration tests pass
- [x] **Updated Tests**
  - Unit and integration tests have been added that describe the bug that was fixed or the features that were added
- [x] Documentation
  - All new environment variables added to `.env.schema` file and documented in the README
  - All changes to server HTTP endpoints have open-api documentation
  - All new functions exported from their module have TSDoc comment documentation
