### PR TITLE
✨ Feat - Adds option for customizing tickValues on BarChart bottom axis

### DIFF
--- a/modules/charts/src/components/charts/Bar/BarChart.tsx
+++ b/modules/charts/src/components/charts/Bar/BarChart.tsx
@@ -15,7 +15,7 @@ export interface NumericAggregationsOptions {
 	ranges?: Ranges;
 }
 
-interface SupportedNivo {
+export interface SupportedNivo {
 	axisLeft: { legend: any };
 	axisBottom: { legend: any };
 }
@@ -24,7 +24,7 @@ export interface BarChartProps {
 	fieldName: string;
 	maxBars: number;
 	ranges?: Ranges;
-	theme: { sortByKey?: string[] } & SupportedNivo;
+	theme: { sortByKey?: string[]; axisBottom: { customTickValueSize?: number } } & SupportedNivo;
 	handlers?: { onClick: (config: any) => void };
 	disableTopBarsCount?: boolean;
 }

--- a/modules/charts/src/components/charts/Bar/View.tsx
+++ b/modules/charts/src/components/charts/Bar/View.tsx
@@ -1,9 +1,10 @@
 import { css } from '@emotion/react';
 import { ResponsiveBar } from '@nivo/bar';
+import { maxBy, omit } from 'lodash';
 import { useMemo } from 'react';
 
 import { useColorMap } from '#hooks/useColorMap';
-import { BarChartProps } from './BarChart';
+import { BarChartProps, SupportedNivo } from './BarChart';
 import { arrangerToNivoBarChart } from './nivo/config';
 
 const SUPPRESSION_INCREMENT_VALUE = 0.2;
@@ -14,6 +15,7 @@ interface BarChartViewProps {
 	theme: BarChartProps['theme'];
 	maxBars: BarChartProps['maxBars'];
 	colorMapRef: React.RefObject<Map<string, string>>;
+	fieldName: string;
 }
 
 type BarData = {
@@ -44,6 +46,64 @@ const colorMapResolver = ({ chartData, savedMap, colors }) => {
 };
 
 /**
+ * Creates a numeric array of even multiples.
+ *
+ * @remarks The start value is expected to be higher than the stop value.
+ *
+ * @param start starting value of array
+ * @param stop final value of the array
+ * @param step value for the multiple of each element in the array
+ * @returns an array of numbers
+ */
+const range = (start: number, stop: number, step: number): number[] => {
+	if (start >= stop || stop - start < step) {
+		return [start, stop];
+	}
+	return Array.from({ length: Math.ceil((stop - start) / step) }, (_, i) => start + i * step);
+};
+
+type CustomAxisBottomTheme = {
+	axisBottom?: { tickValues?: number[] };
+	maxValue?: number;
+	legend?: string;
+};
+type AxisBottomTheme = SupportedNivo['axisBottom'] & { customTickValueSize?: number };
+
+/**
+ * Creates a custom array of tickValues for the bottom axis of a Bar Chart, if customTicks.size is provided. These values
+ * will be multiples of the provided size. Includes a maxValue to pass to the Chart props to ensure a final x-axis value is provided,
+ * if the highest value in the chart data does not match the highest value in the tickValues array.
+ * Returns a CustomAxisBottomTheme object.
+ *
+ * If customTicks.size is not provided, returns the original object provided to the axisBottomTheme argument.
+ *
+ * @param data BarData
+ * @param axisBottomTheme arguments provide to the theme.axisBottom prop of the Bar Chart
+ * @returns CustomAxisBottomTheme
+ */
+const calculateCustomTickValues = (data: BarData[], axisBottomTheme: AxisBottomTheme): CustomAxisBottomTheme => {
+	if (axisBottomTheme.customTickValueSize) {
+		const { customTickValueSize } = axisBottomTheme;
+		const maxValue = maxBy(data, 'value')?.value || customTickValueSize;
+		const maxMultipleValue = Math.ceil(maxValue / customTickValueSize) * customTickValueSize;
+
+		const tickValues: number[] = range(0, maxValue + customTickValueSize, customTickValueSize);
+
+		return {
+			maxValue: maxMultipleValue,
+			axisBottom: {
+				...omit(axisBottomTheme, 'customTickValueSize'),
+				tickValues,
+			},
+		};
+	}
+
+	return {
+		legend: axisBottomTheme.legend,
+	};
+};
+
+/**
  * Renders a responsive Nivo bar chart with Arranger theme integration.
  * Handles click interactions and applies consistent styling.
  *
@@ -58,6 +118,7 @@ export const BarChartView = ({ data, handlers, theme, maxBars, colorMapRef, fiel
 	// persistent color map
 	// ensure to create from full data available before slicing visible data
 	const { colorMap } = useColorMap({ fieldName, colorMapRef, chartData: data, resolver: colorMapResolver });
+	const customTickValues: CustomAxisBottomTheme | {} = calculateCustomTickValues(data, theme.axisBottom);
 
 	/**
 	 * TODO: improve "chart view" config/interface
@@ -65,7 +126,8 @@ export const BarChartView = ({ data, handlers, theme, maxBars, colorMapRef, fiel
 	 * handlers currently only support onClick
 	 */
 	const resolvedTheme = useMemo(
-		() => arrangerToNivoBarChart({ theme, colorMap, onClick: handlers?.onClick }),
+		() =>
+			arrangerToNivoBarChart({ theme: { ...theme, ...customTickValues }, colorMap, onClick: handlers?.onClick }),
 		[theme, colorMap, handlers],
 	);
 
@@ -80,7 +142,7 @@ export const BarChartView = ({ data, handlers, theme, maxBars, colorMapRef, fiel
 	// 1) custom sort order or ascending (from axis)
 	// 2) limit by maxRows
 	// 3) reverse order for display
-	const barData = theme.sortByKey
+	const barData: BarData[] = theme.sortByKey
 		? theme.sortByKey
 				.map((label) => dataWithSuppressedValues.find((bar: BarData) => bar.key === label))
 				.filter(Boolean)
@@ -93,6 +155,7 @@ export const BarChartView = ({ data, handlers, theme, maxBars, colorMapRef, fiel
 	return (
 		<div css={css({ width: '100%', height: '100%' })}>
 			<ResponsiveBar
+				ariaLabel={`${fieldName}-bar-chart`}
 				data={barData}
 				{...resolvedTheme}
 			/>


### PR DESCRIPTION
## Summary

Adds option to customize the step size of the Bar Chart bottom axis + one minor accessibility fix for the BarChart.

**Note**: This PR uses https://github.com/overture-stack/arranger/pull/1074 as its base branch, as it is modifying the same files.

## Issues
[OHCRN Platform #1909](https://github.com/OHCRN/platform/issues/1909)

## Description of Changes

### Charts Module
- adds a new numeric prop `customTickValueSize` to the BarChart`theme.axisBottom` object. Providing a value here will set the size of multiples used in the chart's x-axis. For example, if the value is `4`, the axis ticks will display in multiples of 4: `[0, 4, 8, 12, ...]`.
- if no value is provided, the bottom axis will calculate its tick multiples automatically based on the min/max of the chart data (no change in current behaviour)
- adds an `ariaLabel`  to the BarChart

### Special Instructions
n/a

## Readiness Checklist

- [x] **Self Review**
  - I have performed a self review of code
  - I have run the application locally and manually tested the feature
  - I have checked all updates to correct typos and misspellings
- [x] **Formatting**
  - Code follows the project style guide
  - Autmated code formatters (ie. Prettier) have been run
- [x] **Local Testing**
  - Successfully built all packages locally
  - Successfully ran all test suites, all unit and integration tests pass
- [ ] **Updated Tests**
  - Unit and integration tests have been added that describe the bug that was fixed or the features that were added
- [x] Documentation
  - All new environment variables added to `.env.schema` file and documented in the README
  - All changes to server HTTP endpoints have open-api documentation
  - All new functions exported from their module have TSDoc comment documentation
