### PR TITLE
⚡️ Add few-shot examples and a "SQON Cheat Sheet" to improve LLM SQON Generation

### DIFF
--- a/.dev/sessions.md
+++ b/.dev/sessions.md
@@ -137,6 +137,35 @@ Added `getAllData` to the `graphql-router` utils barrel export (was missing, cau
 - `modules/graphql-router/src/utils/index.ts`: re-exported `getAllData` as a named export; must evaluate whether this is a desirable pattern for future versions
 - `.dev/tech-debt.md`: `integration-tests/import` entry extended with two TODOs: verify each `exports` subpath by name (not just the root), and document what each exported method is and what it is for
 
+**Done:**
+
+- Improved SQON-generation success for smaller LLMs calling the MCP `execute-query` tool (two enhancements targeting the documented root causes from the 2026-06-11 analysis):
+    - `apps/mcp-server/src/mcp/executeQueryTool.ts`: rewrote the `sqon` input parameter `.describe()` into an inline few-shot. Spells out the GROUP vs LEAF shapes, that a leaf nests `fieldName`/`value` inside `content` (the key is `fieldName`, never `field`, and they never sit beside `op`), a correct "donors are Female" example, the exact WRONG flat-leaf shape to avoid, and the empty-root `{"op":"and","content":[]}` for unfiltered queries. Reinforces correct shape at the point of use, where the model errs even after reading the schema.
+    - `apps/mcp-server/src/mcp/tools.ts`: replaced the `get-sqon-schema` tool's `text` content (previously the raw `zodToJsonSchema` dump) with a compact, ASCII-only SQON cheat sheet: grammar (Group/Leaf), field operators grouped by applicability, the `filter`-op `fieldNames`-array exception, pitfalls (flat leaf; booleans as strings), a symbol-alias note, and seven worked examples plus the WRONG example. The full machine-readable schema and operator metadata stay in `structuredContent`, so nothing is lost for clients that read it. Tool `description` updated to advertise the quick reference.
+- Verified all seven cheat-sheet/param examples parse against the real `SqonSchema.safeParse`, and the WRONG flat-leaf example is rejected (one-off script, not committed).
+- Updated `integration-tests/mcp-server/test/readTools.ts` test 2: the `get-sqon-schema` text is now prose, so it asserts the cheat sheet mentions SQON and `fieldName`, and reads the version/title/schema/operators payload from `structuredContent` (mirrors the test-3 pattern).
+- `npm run test -w apps/mcp-server` green (67 tests); `tsc -p apps/mcp-server` clean.
+
+**Done (follow-up, after a local-LLM retest with gemma-4-e4b still produced invalid SQON):**
+
+- Reviewed three description/cheat-sheet suggestions the model itself produced. Every SQON structure in its suggested examples was invalid (verified against `SqonSchema.safeParse`): it placed `fieldName` beside `op` with only `value` inside `content`, and wrote `op:"not"` as a leaf with a bogus `"in"` key. Incorporated the pedagogy, not the structures.
+- Reworked the `get-sqon-schema` cheat sheet (`tools.ts`): front-loaded a "THE MISTAKE TO AVOID" block showing the CORRECT leaf next to the two real malformed shapes (fieldName-beside-op, and flat `field`); added a copyable leaf template, a 3-step build recipe ("always wrap in a Group root"), a multi-value `in` note, a negation note (`not` group or `not-in`), and an OR example; reframed the worked examples as "Natural language to SQON". Re-verified every example against `SqonSchema`.
+- Strengthened the `sqon` param description (`executeQueryTool.ts`): added the exact fieldName-beside-op failure as a second WRONG example, plus "always use a group as the root, even for a single condition" (which also dodges the known root-leaf `buildAggregations` crash).
+- Strengthened the `execute-query` tool description: explicit "translate the request into a SQON filter tree; call get-sqon-schema if unsure" step (the LLM's workflow suggestion, minus its LaTeX/emoji). Cleaned three pre-existing em-dashes in this file's param/JSDoc text (convention compliance).
+
+**Decisions:**
+
+- The local LLM's own suggested example structures were invalid and were not copied; only the presentation ideas (natural-language-to-SQON framing, the leaf template, the build recipe, the explicit CORRECT-vs-WRONG failure contrast, the OR case, the workflow mandate) were incorporated, with every example verified against `SqonSchema`.
+- Recommend always wrapping in a Group root (even single conditions): it both keeps the model on one consistent pattern and sidesteps the open `buildAggregations` root-leaf bug for `aggregations`/`both`.
+- The cheat sheet is hand-maintained in `tools.ts`, not derived from the schema and not hoisted into `modules/sqon`: smaller LLMs pattern-match examples rather than execute a recursive JSON Schema, and the few-shot examples cannot be auto-generated. A code comment flags that the operator names and node shapes must track `modules/sqon/src/schema`. The operator set is stable, so drift risk is low.
+- Kept `structuredContent` as the full payload (the validation artifact) and made `text` the generation guide; this is the content/structuredContent split MCP already supports.
+
+**Open threads:**
+
+- Awaiting a retest of the revised cheat sheet / descriptions against gemma-4-e4b. Prompt-engineering alone may not be enough for a ~4B model that ignores or under-attends to the guidance; if it still fails, the higher-leverage fixes are the structural root causes below (especially #5: a mistake-aware validation error would let the model self-correct in a loop rather than depend on getting it right first try).
+- `/docs` debt: this changes the MCP `get-sqon-schema` and `execute-query` tool-surface behaviour (cheat sheet text, richer param description); the MCP tool surface remains undocumented in `/docs`.
+- Remaining root causes from the 2026-06-11 analysis are still open and are the natural next steps: the `sqon` input is still `zod.unknown()` (no protocol-level structure for schema-constrained clients); Zod union errors still collapse to `Invalid SQON at root: Invalid input` (broken self-correction loop); the published JSON Schema still has dangling `$ref`s (tech-debt, standalone).
+
 ---
 
 ## 2026-06-19

--- a/.dev/tech-debt.md
+++ b/.dev/tech-debt.md
@@ -159,15 +159,6 @@ When Arranger Server (`apps/search-server`) is updated to use `catalogue`, the M
 **Fix:** (a) Docs/schema comments pass: update README.md:13, docs/usage/02-arranger-components.md (title + line 29), configs.json.schema:28, and console strings in configs/index.ts. (b) Identifier rename pass (separate commit): buildCatalogsFromFolder -> buildCatalogsFromDirectory, folderName -> directoryName in apps/search-server/src/configs/. (c) Cross-references: add pointer to docs/concepts.md early in docs/usage/02-arranger-components.md; introduce "filter clause" for leaf nodes in docs/sqon/03-sqon-in-detail.md.
 **Standalone:** yes; (a) is docs-only; (b) is a mechanical rename; (c) is a docs addition. All three independent.
 
-### `docs/concepts.md` SQON examples use `field` instead of `fieldName`
-
-**File:** `docs/concepts.md:44,56-57`
-**Severity:** medium (canonical concepts doc contradicts the runtime schema; actively trains LLMs and readers into the #1 invalid-SQON mistake)
-**Kind:** stale documentation
-**Issue:** The SQON examples in `docs/concepts.md` use `"field"` as the filter-clause key, but the runtime (`modules/sqon` `SqonLeafSchema`, and `buildQuery` in `graphql-router` which reads `content.fieldName`) requires `"fieldName"`. `field` is the legacy/GDC-era spelling and is exactly the key local LLMs keep producing when generating SQON for the MCP `execute-query` tool — the project's own docs reinforce the wrong prior. `docs/usage/00-query-processing.md` already uses `fieldName` correctly.
-**Fix:** Update the examples in `concepts.md` to `fieldName`; grep docs for any other `"field"` usages in SQON (not ES query) context.
-**Standalone:** yes — docs-only change
-
 ### `setup.md` references `.env.arrangerDev` which no longer exists in the repo
 
 **File:** `docs/setup.md`; step 2 of "Running the Arranger-Server"

--- a/apps/mcp-server/src/mcp/executeQueryTool.ts
+++ b/apps/mcp-server/src/mcp/executeQueryTool.ts
@@ -235,7 +235,7 @@ export const registerExecuteQueryTool = (server: McpServer, { client }: McpServe
 				'2. call get-catalogue-fields to discover valid field names and per-type SQON operators. ' +
 				'3. call get-sqon-schema to learn how to construct valid SQON and see worked examples. ' +
 				'DO NOT guess field names, you MUST call get-catalogue-fields. ' +
-				'DO NOT construct "sqon" without callling get-sqon-schema. ' +
+				'DO NOT construct "sqon" without calling get-sqon-schema. ' +
 				'The user is asked to review and confirm the generated GraphQL query before it runs (when the client supports elicitation).',
 			inputSchema,
 			outputSchema,

--- a/apps/mcp-server/src/mcp/executeQueryTool.ts
+++ b/apps/mcp-server/src/mcp/executeQueryTool.ts
@@ -33,7 +33,15 @@ const inputSchema = {
 	sqon: zod
 		.unknown()
 		.describe(
-			'SQON filter for the query. Required. For an unfiltered query ("show me everything"), pass the empty root SQON {"op": "and", "content": []} — never null. Use get-sqon-schema for the SQON structure and get-catalogue-fields for valid fields and per-type operators.',
+			'SQON filter for the query (required). A SQON is a tree of two node kinds: group and leaf. ' +
+				'A GROUP combines conditions: {"op": "and" | "or" | "not", "content": [ ...child nodes... ]} (content is an ARRAY). ' +
+				'A LEAF is one field condition: {"op": "in" | "gt" | ..., "content": {"fieldName": "<field>", "value": <scalar or array>}} (content is an OBJECT). ' +
+				'Key rule: in a leaf, "fieldName" and "value" go TOGETHER inside "content", "op" stays outside, and the key is "fieldName", never "field". ' +
+				'CORRECT (donors that are Female): {"op":"and","content":[{"op":"in","content":{"fieldName":"donors.gender","value":["Female"]}}]}. ' +
+				'WRONG (rejected): {"op":"and","content":[{"fieldName":"donors.gender","op":"in","content":{"value":["Female"]}}]} (fieldName must be inside content, not beside op). ' +
+				'WRONG (rejected): {"op":"and","content":[{"field":"donors.gender","op":"in","value":["Female"]}]} ("field" should be "fieldName", and the condition is not nested). ' +
+				'Always use a group as the root, even for a single condition. For an unfiltered query ("show me everything") pass {"op":"and","content":[]}, never null. ' +
+				'Call get-sqon-schema for the cheat sheet and get-catalogue-fields for valid field names and per-type operators.',
 		),
 	queryType: zod
 		.enum(['hits', 'aggregations', 'both'])
@@ -45,7 +53,7 @@ const inputSchema = {
 		.array(zod.string().min(1))
 		.optional()
 		.describe(
-			'Dot-notation document fields to return for each hit (e.g. "donor.age_at_diagnosis"). Do not guess field names — use get-catalogue-fields first. Omit to return only the total hit count.',
+			'Dot-notation document fields to return for each hit (e.g. "donor.age_at_diagnosis"). Do not guess field names; use get-catalogue-fields first. Omit to return only the total hit count.',
 		),
 	first: zod
 		.number()
@@ -68,7 +76,7 @@ const inputSchema = {
 		.array(zod.string().min(1))
 		.optional()
 		.describe(
-			'Fields to aggregate. Nested properties use double underscores (e.g. "donor__age_at_diagnosis"); dot notation is also accepted. Do not guess field names — use get-catalogue-fields first. Required when queryType is "aggregations" or "both".',
+			'Fields to aggregate. Nested properties use double underscores (e.g. "donor__age_at_diagnosis"); dot notation is also accepted. Do not guess field names; use get-catalogue-fields first. Required when queryType is "aggregations" or "both".',
 		),
 	includeMissing: zod
 		.boolean()
@@ -168,7 +176,7 @@ const validateRequest = ({
 /**
  * Asks the user to review and confirm the generated GraphQL request before it is executed,
  * using MCP elicitation. When the connected client does not advertise the elicitation
- * capability, confirmation is skipped and the query proceeds — the executed request is
+ * capability, confirmation is skipped and the query proceeds; the executed request is
  * always echoed in the tool response for transparency.
  * @returns `true` when execution may proceed, `false` when the user declined or cancelled.
  */
@@ -228,7 +236,8 @@ export const registerExecuteQueryTool = (server: McpServer, { client }: McpServe
 			title: 'Execute Arranger Query',
 			description:
 				'Execute a SQON-filtered query against one Arranger catalogue and return matching documents (hits), per-field aggregation summaries, or both. ' +
-				'Before calling this tool: use list-catalogues to find the catalogue, then get-catalogue-fields to discover valid field names and per-type SQON operators — never guess field names. ' +
+				'Translate the user request into a SQON filter tree for the "sqon" argument; if unsure of the structure, call get-sqon-schema for the SQON cheat sheet. ' +
+				'Before calling this tool: use list-catalogues to find the catalogue, then get-catalogue-fields to discover valid field names and per-type SQON operators; never guess field names. ' +
 				'The user is asked to review and confirm the generated GraphQL query before it runs (when the client supports elicitation).',
 			inputSchema,
 			outputSchema,

--- a/apps/mcp-server/src/mcp/executeQueryTool.ts
+++ b/apps/mcp-server/src/mcp/executeQueryTool.ts
@@ -33,15 +33,9 @@ const inputSchema = {
 	sqon: zod
 		.unknown()
 		.describe(
-			'SQON filter for the query (required). A SQON is a tree of two node kinds: group and leaf. ' +
-				'A GROUP combines conditions: {"op": "and" | "or" | "not", "content": [ ...child nodes... ]} (content is an ARRAY). ' +
-				'A LEAF is one field condition: {"op": "in" | "gt" | ..., "content": {"fieldName": "<field>", "value": <scalar or array>}} (content is an OBJECT). ' +
-				'Key rule: in a leaf, "fieldName" and "value" go TOGETHER inside "content", "op" stays outside, and the key is "fieldName", never "field". ' +
-				'CORRECT (donors that are Female): {"op":"and","content":[{"op":"in","content":{"fieldName":"donors.gender","value":["Female"]}}]}. ' +
-				'WRONG (rejected): {"op":"and","content":[{"fieldName":"donors.gender","op":"in","content":{"value":["Female"]}}]} (fieldName must be inside content, not beside op). ' +
-				'WRONG (rejected): {"op":"and","content":[{"field":"donors.gender","op":"in","value":["Female"]}]} ("field" should be "fieldName", and the condition is not nested). ' +
-				'Always use a group as the root, even for a single condition. For an unfiltered query ("show me everything") pass {"op":"and","content":[]}, never null. ' +
-				'Call get-sqon-schema for the cheat sheet and get-catalogue-fields for valid field names and per-type operators.',
+			'SQON filter for the query (required). ' +
+				'Call get-sqon-schema before using execute-query for SQON grammar, operators, and worked examples. ' +
+				'For an unfiltered query ("show me everything") pass {"op":"and","content":[]}, never null.',
 		),
 	queryType: zod
 		.enum(['hits', 'aggregations', 'both'])
@@ -236,8 +230,12 @@ export const registerExecuteQueryTool = (server: McpServer, { client }: McpServe
 			title: 'Execute Arranger Query',
 			description:
 				'Execute a SQON-filtered query against one Arranger catalogue and return matching documents (hits), per-field aggregation summaries, or both. ' +
-				'Translate the user request into a SQON filter tree for the "sqon" argument; if unsure of the structure, call get-sqon-schema for the SQON cheat sheet. ' +
-				'Before calling this tool: use list-catalogues to find the catalogue, then get-catalogue-fields to discover valid field names and per-type SQON operators; never guess field names. ' +
+				'Before calling this tool you MUST: ' +
+				'1. use list-catalogues to find the catalogue. ' +
+				'2. call get-catalogue-fields to discover valid field names and per-type SQON operators. ' +
+				'3. call get-sqon-schema to learn how to construct valid SQON and see worked examples. ' +
+				'DO NOT guess field names, you MUST call get-catalogue-fields. ' +
+				'DO NOT construct "sqon" without callling get-sqon-schema. ' +
 				'The user is asked to review and confirm the generated GraphQL query before it runs (when the client supports elicitation).',
 			inputSchema,
 			outputSchema,

--- a/apps/mcp-server/src/mcp/tools.ts
+++ b/apps/mcp-server/src/mcp/tools.ts
@@ -10,6 +10,62 @@ import {
 import { registerExecuteQueryTool } from '#mcp/executeQueryTool.js';
 import { type McpServerDeps } from '#server.js';
 
+/**
+ * Compact, LLM-oriented SQON quick reference returned as the human-readable text of the
+ * `get-sqon-schema` tool. The full machine-readable JSON Schema, operator list, and aliases
+ * are returned alongside it in the tool's `structuredContent`, so nothing is lost: this text
+ * is the generation guide, the structuredContent is the validation artifact.
+ *
+ * Smaller LLMs pattern-match examples far more reliably than they "execute" a recursive JSON
+ * Schema, so this leads with the single most common mistake (fieldName/value placed beside "op"
+ * instead of inside "content"), then gives the Group/Leaf shapes, a copyable leaf template, a
+ * build recipe, and natural-language-to-SQON worked examples. Keep it in sync by hand with the
+ * SQON schema in `@overture-stack/sqon` (modules/sqon/src/schema): the operator names and node
+ * shapes below are derived from it. Every example here is checked against `SqonSchema`.
+ */
+const SQON_CHEAT_SHEET = `SQON cheat sheet (Serializable Query Object Notation).
+This text is a quick reference for writing the "sqon" filter. The full machine-readable JSON Schema, operator list, and aliases are in this tool's structuredContent.
+
+Grammar:
+  SQON  = Group | Leaf
+  Group = {"op": "and" | "or" | "not", "content": [ SQON, ... ]}      (content is an ARRAY of child nodes; combines conditions)
+  Leaf  = {"op": <field op>, "content": {"fieldName": "<dot.path>", "value": <scalar or array>}}   (content is an OBJECT; one condition)
+  Leaf template to copy and fill in:  {"op": "<field op>", "content": {"fieldName": "<field>", "value": <value>}}
+
+Field operators (the "op" of a Leaf):
+  in, not-in, some-not-in, all   match value(s); any field type; "value" is a scalar or array
+  gt, gte, lt, lte               numeric or date fields; "value" is a single number or date string
+  between                        numeric or date fields; "value" is a 2-element array, [min, max]
+  filter                         fuzzy text match; SPECIAL shape: {"op":"filter","content":{"fieldNames":["<field>"],"value":"<text>"}}  ("fieldNames" is a plural ARRAY; "value" is one string)
+
+How to build a SQON:
+  1. Find each field's path and its allowed operators with get-catalogue-fields.
+  2. Write every condition as a Leaf: {"op": <op>, "content": {"fieldName": <field>, "value": <value>}}.
+  3. Wrap all the Leaves in one root Group: {"op":"and","content":[ <leaf>, <leaf>, ... ]}. Use "or" for any-of, or "not" to negate.
+  Always use a Group as the root, even for a single condition.
+
+THE MISTAKE TO AVOID (this is what usually fails):
+  In a LEAF, "fieldName" and "value" go TOGETHER inside "content"; "op" stays outside; the key is "fieldName", never "field".
+  CORRECT: {"op":"in","content":{"fieldName":"donors.gender","value":["Female"]}}
+  WRONG:   {"fieldName":"donors.gender","op":"in","content":{"value":["Female"]}}   (fieldName must be INSIDE content, not beside op)
+  WRONG:   {"field":"donors.gender","op":"in","value":["Female"]}                   ("field" should be "fieldName", and nothing is nested in content)
+
+Notes:
+  - "value" items are strings or numbers. Send booleans as the strings "true" or "false".
+  - Several allowed values for one field: use one "in" Leaf with an array, e.g. "value":["Female","Male"] (the array means "any of").
+  - To negate, wrap a Group {"op":"not","content":[ <leaf> ]}, or use the "not-in" operator on a Leaf.
+  - Symbol aliases exist (>, >=, <, <= for gt, gte, lt, lte; = for in; != for not-in) but prefer the word forms.
+
+Natural language to SQON examples:
+  Female donors:           {"op":"and","content":[{"op":"in","content":{"fieldName":"donors.gender","value":["Female"]}}]}
+  Age over 50:             {"op":"and","content":[{"op":"gt","content":{"fieldName":"donors.age_at_diagnosis","value":50}}]}
+  Female and age >= 18:    {"op":"and","content":[{"op":"in","content":{"fieldName":"donors.gender","value":["Female"]}},{"op":"gte","content":{"fieldName":"donors.age_at_diagnosis","value":18}}]}
+  Female or age over 65:   {"op":"or","content":[{"op":"in","content":{"fieldName":"donors.gender","value":["Female"]}},{"op":"gt","content":{"fieldName":"donors.age_at_diagnosis","value":65}}]}
+  Exclude deceased:        {"op":"and","content":[{"op":"not-in","content":{"fieldName":"donors.vital_status","value":["Deceased"]}}]}
+  Age between 18 and 65:   {"op":"and","content":[{"op":"between","content":{"fieldName":"donors.age_at_diagnosis","value":[18,65]}}]}
+  Fuzzy text match:        {"op":"and","content":[{"op":"filter","content":{"fieldNames":["donors.primary_site"],"value":"brain"}}]}
+  Everything (no filter):  {"op":"and","content":[]}`;
+
 export const registerTools = (server: McpServer, deps: McpServerDeps): void => {
 	const { client } = deps;
 	server.registerTool(
@@ -34,14 +90,15 @@ export const registerTools = (server: McpServer, deps: McpServerDeps): void => {
 		'get-sqon-schema',
 		{
 			title: 'Get SQON Schema',
-			description: 'Returns the shared SQON Schema and operator metadata for the connected Arranger server.',
+			description:
+				'Returns a compact SQON quick reference (grammar, operators, and worked examples) for writing valid filters, plus the full machine-readable SQON JSON Schema and operator metadata in structuredContent.',
 			outputSchema: sqonIntrospectionSchema,
 		},
 		async () => {
 			const data = await client.getSqonIntrospection();
 			const sqonSchema = sqonIntrospectionSchema.parse(data);
 			return {
-				content: [{ type: 'text', text: JSON.stringify(sqonSchema) }],
+				content: [{ type: 'text', text: SQON_CHEAT_SHEET }],
 				structuredContent: sqonSchema,
 			};
 		},

--- a/apps/mcp-server/src/mcp/tools.ts
+++ b/apps/mcp-server/src/mcp/tools.ts
@@ -36,7 +36,7 @@ Field operators (the "op" of a Leaf):
   in, not-in, some-not-in, all   match value(s); any field type; "value" is a scalar or array
   gt, gte, lt, lte               numeric or date fields; "value" is a single number or date string
   between                        numeric or date fields; "value" is a 2-element array, [min, max]
-  filter                         fuzzy text match; SPECIAL shape: {"op":"filter","content":{"fieldNames":["<field>"],"value":"<text>"}}  ("fieldNames" is a plural ARRAY; "value" is one string)
+  wildcard                         case-insensitive substring match; SPECIAL shape: {"op":"wildcard","content":{"fieldNames":["<field>"],"value":"<text>"}}  ("fieldNames" is a plural ARRAY; "value" is one string)
 
 How to build a SQON:
   1. Find each field's path and its allowed operators with get-catalogue-fields.
@@ -63,7 +63,7 @@ Natural language to SQON examples:
   Female or age over 65:   {"op":"or","content":[{"op":"in","content":{"fieldName":"donors.gender","value":["Female"]}},{"op":"gt","content":{"fieldName":"donors.age_at_diagnosis","value":65}}]}
   Exclude deceased:        {"op":"and","content":[{"op":"not-in","content":{"fieldName":"donors.vital_status","value":["Deceased"]}}]}
   Age between 18 and 65:   {"op":"and","content":[{"op":"between","content":{"fieldName":"donors.age_at_diagnosis","value":[18,65]}}]}
-  Fuzzy text match:        {"op":"and","content":[{"op":"filter","content":{"fieldNames":["donors.primary_site"],"value":"brain"}}]}
+  Wildcard text match:        {"op":"and","content":[{"op":"wildcard","content":{"fieldNames":["donors.primary_site"],"value":"brain"}}]}
   Everything (no filter):  {"op":"and","content":[]}`;
 
 export const registerTools = (server: McpServer, deps: McpServerDeps): void => {

--- a/apps/mcp-server/src/mcp/tools.ts
+++ b/apps/mcp-server/src/mcp/tools.ts
@@ -40,7 +40,7 @@ Field operators (the "op" of a Leaf):
 
 How to build a SQON:
   1. Find each field's path and its allowed operators with get-catalogue-fields.
-  2. Write every condition as a Leaf: {"op": <op>, "content": {"fieldName": "<field>", "value": <value>}}, except for "filter", where "fieldNames" is an array of field paths instead. (See operator table below.)
+  2. Write every condition as a Leaf: {"op": <op>, "content": {"fieldName": "<field>", "value": <value>}}, except for "wildcard", where "fieldNames" is an array of field paths instead. (See operator table below.)
   3. Wrap all the Leaves in one root Group: {"op":"and","content":[ <leaf>, <leaf>, ... ]}. Use "or" for any-of, or "not" to negate.
   Always use a Group as the root, even for a single condition.
 
@@ -51,7 +51,7 @@ THE MISTAKE TO AVOID (this is what usually fails):
   WRONG:   {"field":"donors.gender","op":"in","value":["Female"]}                   ("field" should be "fieldName", and nothing is nested in content)
 
 Notes:
-  - "value" items are strings or numbers. Send booleans as the strings "true" or "false".
+  - "value" items are strings, numbers, or booleans. 
   - Several allowed values for one field: use one "in" Leaf with an array, e.g. "value":["Female","Male"] (the array means "any of").
   - To negate, wrap a Group {"op":"not","content":[ <leaf> ]}, or use the "not-in" operator on a Leaf.
   - Symbol aliases exist (>, >=, <, <= for gt, gte, lt, lte; = for in; != for not-in) but prefer the word forms.

--- a/apps/mcp-server/src/mcp/tools.ts
+++ b/apps/mcp-server/src/mcp/tools.ts
@@ -40,7 +40,7 @@ Field operators (the "op" of a Leaf):
 
 How to build a SQON:
   1. Find each field's path and its allowed operators with get-catalogue-fields.
-  2. Write every condition as a Leaf: {"op": <op>, "content": {"fieldName": <field>, "value": <value>}}.
+  2. Write every condition as a Leaf: {"op": <op>, "content": {"fieldName": "<field>", "value": <value>}}, except for `filter`, where "fieldNames" is an array of field paths instead. (See operator table below.)
   3. Wrap all the Leaves in one root Group: {"op":"and","content":[ <leaf>, <leaf>, ... ]}. Use "or" for any-of, or "not" to negate.
   Always use a Group as the root, even for a single condition.
 

--- a/apps/mcp-server/src/mcp/tools.ts
+++ b/apps/mcp-server/src/mcp/tools.ts
@@ -40,7 +40,7 @@ Field operators (the "op" of a Leaf):
 
 How to build a SQON:
   1. Find each field's path and its allowed operators with get-catalogue-fields.
-  2. Write every condition as a Leaf: {"op": <op>, "content": {"fieldName": "<field>", "value": <value>}}, except for `filter`, where "fieldNames" is an array of field paths instead. (See operator table below.)
+  2. Write every condition as a Leaf: {"op": <op>, "content": {"fieldName": "<field>", "value": <value>}}, except for "filter", where "fieldNames" is an array of field paths instead. (See operator table below.)
   3. Wrap all the Leaves in one root Group: {"op":"and","content":[ <leaf>, <leaf>, ... ]}. Use "or" for any-of, or "not" to negate.
   Always use a Group as the root, even for a single condition.
 

--- a/apps/mcp-server/src/mcp/tools.ts
+++ b/apps/mcp-server/src/mcp/tools.ts
@@ -36,7 +36,7 @@ Field operators (the "op" of a Leaf):
   in, not-in, some-not-in, all   match value(s); any field type; "value" is a scalar or array
   gt, gte, lt, lte               numeric or date fields; "value" is a single number or date string
   between                        numeric or date fields; "value" is a 2-element array, [min, max]
-  wildcard                         case-insensitive substring match; SPECIAL shape: {"op":"wildcard","content":{"fieldNames":["<field>"],"value":"<text>"}}  ("fieldNames" is a plural ARRAY; "value" is one string)
+  wildcard                       case-insensitive substring match; SPECIAL shape: {"op":"wildcard","content":{"fieldNames":["<field>"],"value":"<text>"}}  ("fieldNames" is a plural ARRAY; "value" is one string)
 
 How to build a SQON:
   1. Find each field's path and its allowed operators with get-catalogue-fields.
@@ -63,7 +63,7 @@ Natural language to SQON examples:
   Female or age over 65:   {"op":"or","content":[{"op":"in","content":{"fieldName":"donors.gender","value":["Female"]}},{"op":"gt","content":{"fieldName":"donors.age_at_diagnosis","value":65}}]}
   Exclude deceased:        {"op":"and","content":[{"op":"not-in","content":{"fieldName":"donors.vital_status","value":["Deceased"]}}]}
   Age between 18 and 65:   {"op":"and","content":[{"op":"between","content":{"fieldName":"donors.age_at_diagnosis","value":[18,65]}}]}
-  Wildcard text match:        {"op":"and","content":[{"op":"wildcard","content":{"fieldNames":["donors.primary_site"],"value":"brain"}}]}
+  Wildcard text match:     {"op":"and","content":[{"op":"wildcard","content":{"fieldNames":["donors.primary_site"],"value":"brain"}}]}
   Everything (no filter):  {"op":"and","content":[]}`;
 
 export const registerTools = (server: McpServer, deps: McpServerDeps): void => {

--- a/integration-tests/mcp-server/test/readTools.ts
+++ b/integration-tests/mcp-server/test/readTools.ts
@@ -31,17 +31,25 @@ export default ({ getClient, configuredCatalogues, expectedFieldsByCatalogue }: 
 		}
 	});
 
-	test("2.'get-sqon-schema' returns a valid SQON introspection payload", async () => {
+	test("2.'get-sqon-schema' returns a SQON cheat sheet plus the full payload in structuredContent", async () => {
 		const result = await getClient().callTool({ name: 'get-sqon-schema' });
-		const text = getTextContent(result);
-		const data = JSON.parse(text);
 
-		assert.equal(typeof data.version, 'string');
-		assert.equal(typeof data.title, 'string');
-		assert.ok(data.schema);
-		assert.ok(data.operators);
-		assert.ok(Array.isArray(data.operators.combination));
-		assert.ok(Array.isArray(data.operators.field));
+		// The text content is a human/LLM-oriented quick reference, not JSON. It must steer
+		// callers toward the correct leaf shape (the "fieldName not field" pitfall).
+		const text = getTextContent(result);
+		assert.ok(text.includes('SQON'), `expected a SQON cheat sheet, got: ${text}`);
+		assert.ok(text.includes('fieldName'), 'expected the cheat sheet to mention "fieldName"');
+
+		// The full machine-readable schema and operator metadata move to structuredContent.
+		const data = (result as { structuredContent?: Record<string, unknown> }).structuredContent;
+		assert.ok(data, "expected 'get-sqon-schema' to return structuredContent");
+		assert.equal(typeof data?.version, 'string');
+		assert.equal(typeof data?.title, 'string');
+		assert.ok(data?.schema);
+		const operators = data?.operators as { combination?: unknown; field?: unknown } | undefined;
+		assert.ok(operators);
+		assert.ok(Array.isArray(operators?.combination));
+		assert.ok(Array.isArray(operators?.field));
 	});
 
 	test("3.'get-catalogue-fields' returns field metadata for each configured catalogue", async () => {

--- a/integration-tests/mcp-server/test/readTools.ts
+++ b/integration-tests/mcp-server/test/readTools.ts
@@ -41,7 +41,7 @@ export default ({ getClient, configuredCatalogues, expectedFieldsByCatalogue }: 
 		assert.ok(text.includes('fieldName'), 'expected the cheat sheet to mention "fieldName"');
 
 		// The full machine-readable schema and operator metadata move to structuredContent.
-		const data = (result as { structuredContent?: Record<string, unknown> }).structuredContent;
+		const data = result.structuredContent as Record<string, unknown> | undefined;
 		assert.ok(data, "expected 'get-sqon-schema' to return structuredContent");
 		assert.equal(typeof data?.version, 'string');
 		assert.equal(typeof data?.title, 'string');


### PR DESCRIPTION
## Summary

Enhancements to PR #1077 to improve the likelihood that smaller LLMs such as `gemma-4-e4b` can successfully generate valid SQON for use with the `execute-query` tool. Adds few-shot examples of valid SQON, as well as clear instructions on how to build SQON from a user's query.

## Issues

- https://github.com/overture-stack/admin/issues/177

## Description of Changes

Initial testing of the `execute-query` tool with a small local LLM (`gemma-4-e4b`) revealed that despite having access to the full SQON schema from the `get-sqon-schema` tool, small LLMs still failed to produce valid SQON. An analysis led by a Claude thinking model determined 5 potential root causes for the failures, summarized below:

1. Prior training for the model (based on outdated/inaccurate Arranger docs) conflicts with the schema
2. `get-sqon-schema` returns a validation artifact, not a generation guide
3. The published JSON schema contains dangling `$ref`s
4. The `sqon` input parameter to `execute-query` is `Zod.unknown()`, which provides zero structure at the protocol level
5. Error responses for invalid SQON provide little helpful detail for LLM self-correction

The docs have since been updated (thanks, @justincorrigible !), so this PR focuses on issues 1 and 2 as follows:

1. Provide few-shot examples of valid SQON at every touchpoint the LLM has in the `execute-query`/SQON-generation flow, aiming to take precedence over any prior training.
2. Update the `text` response of `get-sqon-schema` to be a SQON generation guide, while keeping the `structuredContent` as the full JSON schema.

Local re-testing with `gemma-4-e4b` following these 2 enhancements has shown promising results so far, allowing the model to generate valid SQON for some basic example queries.

### MCP Server

* Added few-shot examples of valid SQON to the `sqon` parameter description in the `execute-query` tool
* Added a "SQON Cheat Sheet" as the `text` response from the `get-sqon-schema` tool, while still returning the full schema response in `structuredContent`
  * The cheat sheet is structured to help LLMs understand how to structure SQON and build a query, with examples to reinforce best practices and override any erroneous/outdated training data
* Updated the `execute-query` tool description to reinforce utilizing the "SQON cheat sheet"
* Updated `get-sqon-schema` integration tests to reflect new response structure

### Special Instructions

There are no additional steps required to test these changes.

## Readiness Checklist

- [x] **Self Review**
  - I have performed a self review of code
  - I have run the application locally and manually tested the feature
  - I have checked all updates to correct typos and misspellings
- [x] **Formatting**
  - Code follows the project style guide
  - Autmated code formatters (ie. Prettier) have been run
- [x] **Local Testing**
  - Successfully built all packages locally
  - Successfully ran all test suites, all unit and integration tests pass
- [x] **Updated Tests**
  - Unit and integration tests have been added that describe the bug that was fixed or the features that were added
- [x] Documentation
  - All new environment variables added to `.env.schema` file and documented in the README
  - All changes to server HTTP endpoints have open-api documentation
  - All new functions exported from their module have TSDoc comment documentation
