### PR TITLE
add tooltip classnames

### DIFF
--- a/modules/charts/src/components/TooltipContainer.tsx
+++ b/modules/charts/src/components/TooltipContainer.tsx
@@ -4,6 +4,7 @@ import { PropsWithChildren } from 'react';
 export const TooltipContainer = ({ children }: PropsWithChildren<{}>) => {
 	return (
 		<div
+			className="tooltip-container"
 			css={css({
 				fontFamily: 'Work Sans, sans-serif',
 				fontSize: '11px',

--- a/modules/charts/src/components/charts/Tooltip.tsx
+++ b/modules/charts/src/components/charts/Tooltip.tsx
@@ -24,19 +24,22 @@ export const Tooltip = (tooltipData: Bar | SunburstSegment) => {
 	const { value, label, suppressed } = normalizeTooltipProps(tooltipData);
 	return (
 		<TooltipContainer>
-			<div>
-				<div>{`${label}`}</div>
-				<div>
+			<div className="tooltip-wrapper">
+				<div
+					className="tooltip-label"
+					data-label={label} // use this as a CSS selector, to select labels by their content
+				>{`${label}`}</div>
+				<div className="tooltip-data">
 					{suppressed ? (
-						<span>Too few</span>
+						<span className="tooltip-data-suppressed">Too few</span>
 					) : (
 						<>
-							<span>{value}</span>
+							<span className="tooltip-data-value">{value}</span>
 							<span className="tooltip-data-source-wrapper">
 								<span className="tooltip-data-source">: Record</span>
 							</span>
 							{/* TODO: Fix custom tooltip content so we are able to use pluralize; currently does not work if a custom label is applied with CSS */}
-							<span>{value > 1 ? 's' : ''}</span>
+							<span className="tooltip-data-plural">{value > 1 ? 's' : ''}</span>
 						</>
 					)}
 				</div>

--- a/modules/charts/src/components/charts/Tooltip.tsx
+++ b/modules/charts/src/components/charts/Tooltip.tsx
@@ -27,7 +27,8 @@ export const Tooltip = (tooltipData: Bar | SunburstSegment) => {
 			<div className="tooltip-wrapper">
 				<div
 					className="tooltip-label"
-					data-label={label} // use this as a CSS selector, to select labels by their content
+					data-label={label} // CSS selector hook for per-label styling; if building the selector dynamically in JS, escape with CSS.escape() first
+
 				>{`${label}`}</div>
 				<div className="tooltip-data">
 					{suppressed ? (


### PR DESCRIPTION
## Summary

Adds tooltip classnames to Arranger Charts to support styling in OHCRN.

## Issues
- https://github.com/OHCRN/platform/issues/1769

## Description of Changes

### Arranger Charts
- Adds classnames to all divs in the Tooltip component so they can be styled.

## Readiness Checklist

- [x] **Self Review**
  - I have performed a self review of code
  - I have run the application locally and manually tested the feature
  - I have checked all updates to correct typos and misspellings
- [x] **Formatting**
  - Code follows the project style guide
  - Automated code formatters (ie. Prettier) have been run
- [x] **Local Testing**
  - Successfully built all packages locally
  - Successfully ran all test suites, all unit and integration tests pass
- [ ] **Updated Tests**
  - Unit and integration tests have been added that describe the bug that was fixed or the features that were added
- [ ] Documentation
  - All new environment variables added to `.env.schema` file and documented in the README
  - All changes to server HTTP endpoints have open-api documentation
  - All new functions exported from their module have TSDoc comment documentation
