### PR TITLE
docs: use absolute links in migration/v3.1 so vendored docs build

### DIFF
--- a/docs/migration/v3.1.md
+++ b/docs/migration/v3.1.md
@@ -61,13 +61,13 @@ If you want to consolidate multiple instances into one server after upgrading, s
 
 ### `configsSource` parameter will be removed in v3.2
 
-If you use `@overture-stack/arranger-graphql-router` directly (rather than through `apps/search-server`), the `configsSource` string parameter on the router factory is deprecated in 3.1 and will be removed in 3.2. Migrate to passing a configs object directly. See the `graphql-router` [README](../../modules/graphql-router/README.md) for the updated API.
+If you use `@overture-stack/arranger-graphql-router` directly (rather than through `apps/search-server`), the `configsSource` string parameter on the router factory is deprecated in 3.1 and will be removed in 3.2. Migrate to passing a configs object directly. See the `graphql-router` [README](https://github.com/overture-stack/arranger/blob/main/modules/graphql-router/README.md) for the updated API.
 
 ---
 
 ## New features
 
-These additions require no migration for existing deployments. See the [CHANGELOG](../../CHANGELOG.md) for the full feature list with details.
+These additions require no migration for existing deployments. See the [CHANGELOG](https://github.com/overture-stack/arranger/blob/main/CHANGELOG.md) for the full feature list with details.
 
 ---
 


### PR DESCRIPTION
Docs link update