### PR TITLE
chore: Baseline the SQON Contract Before Migrating to Zod 4 (Zod Upgrade Pt 1)

### DIFF
--- a/.dev/tech-debt.md
+++ b/.dev/tech-debt.md
@@ -35,14 +35,16 @@ context: `modules/sqon/README.md` carries a "No stable release yet" section (mar
 **Fix:** Consolidate into `modules/sqon` as the single source of truth. Extend `getSqonFieldOperatorDetails()` to carry the same field-type classification detail that `buildCatalogueIntrospection.ts` currently encodes locally. `buildCatalogueIntrospection.ts` then becomes a thin projection over the module's data. Switch introspection operator lists to canonical names in the same pass (client-visible change). See [roadmap: consolidate field-type-to-operator rules](roadmap.md#consolidate-field-type-to-operator-rules-into-modulessqon).
 **Standalone:** yes; internal refactor; the canonical-name switch changes API output and needs a coordinated note for introspection consumers
 
-### Published SQON JSON Schema contains dangling `$ref` pointers after `anyOf` → `oneOf` normalization
+### Published SQON JSON Schema can emit dangling `$ref` pointers after `anyOf` → `oneOf` normalization (latent)
 
 **File:** `modules/sqon/src/jsonSchema/runtime.ts` (`normalizeUnionKeywords`)
-**Severity:** medium (published schema is not resolvable by strict JSON Schema tooling; confuses LLM consumers of `get_sqon_schema`)
-**Kind:** bug
-**Issue:** `zodToJsonSchema` deduplicates the shared value schema by emitting `$ref` pointers like `#/$defs/All/properties/content/properties/value/anyOf/0` (used by `Between`, `InLike`, `RangeLike`, and inside `All` itself). `normalizeUnionKeywords` then renames every `anyOf` key to `oneOf`, but does not rewrite the `$ref` _path strings_, which still point at `.../anyOf/0`. Those JSON Pointers no longer resolve: the published schema is technically invalid. Permissive consumers won't notice; strict resolvers will fail, and LLMs reading the schema see references into paths that do not exist.
-**Fix:** Either rewrite `$ref` strings during normalization (string-replace `/anyOf/` → `/oneOf/` in `$ref` values), or avoid the problem entirely by inlining the scalar/array value schema instead of cross-def `$ref` chains (better for LLM readability anyway; see the LLM SQON-generation analysis, 2026-06-11 session). Add a test that resolves every `$ref` in the emitted schema.
-**Standalone:** yes; self-contained fix in `runtime.ts` plus a resolution test
+**Severity:** low (latent; medium if triggered, since the published schema stops resolving for strict tooling and confuses LLM consumers of `get_sqon_schema`)
+**Kind:** bug (latent)
+**Issue:** `zodToJsonSchema` emits a `$ref` for every occurrence of a shared subschema after the first, and `normalizeUnionKeywords` renames `anyOf` to `oneOf` without rewriting `$ref` _path strings_. Any pointer routed through an `anyOf` segment stops resolving.
+
+Corrected 2026-09-01: this entry previously called the defect live, and it is not. Every `$ref` currently published resolves, verified by execution. It stays that way only by accident of declaration order: `SqonScalarValueSchema` is a branch of `SqonScalarOrArrayValueSchema`'s union, and `All` happens to lead the `definitions` map, so the first occurrence lands outside any union. Reorder that map so `InLike` leads and the pointer becomes `#/$defs/InLike/properties/content/properties/value/anyOf/0`, the broken shape. Adding an operator that shares a subschema can trip the same wire.
+**Fix:** Guarded as of 2026-09-01: `apps/search-server/src/introspection/introspectionSqonFixtures.test.ts` walks every pointer in the published schema and fails on any that does not resolve, so this can no longer ship silently. The structural fix rides with the Zod 4 migration, where `z.toJSONSchema` plus a registry emits `$ref`s targeting only registry roots and inlines shared subschemas, making the defect class impossible rather than absent (this entry's original second suggestion; see the LLM SQON-generation analysis, 2026-06-11 session). If that migration slips, string-replace `/anyOf/` → `/oneOf/` in `$ref` values during normalization.
+**Standalone:** guard is done; the structural fix rides with the Zod 4 JSON Schema rewrite, or a self-contained `runtime.ts` change if that slips
 
 ### `SqonBuilder.not([...])` inverts AND/OR semantics when merging same-field exclusion filters
 

--- a/.dev/tech-debt.md
+++ b/.dev/tech-debt.md
@@ -289,26 +289,16 @@ Two consumers need updating in the same pass: `dev:check` (which just calls `tes
    **Fix:** Move introspection types into `modules/types` (the existing shared-types package). Define them as Zod schemas there and infer the TS types: `export const CatalogIntrospectionSchema = zod.object({...}); export type CatalogIntrospection = zod.infer<typeof CatalogIntrospectionSchema>`. Both `search-server` and `mcp-server` import from `@overture-stack/arranger-types`: one schema definition, no raw cross-app file paths, and `mcp-server` can reference the schemas directly as MCP `outputSchema` values. The `TODO` comment in `apps/mcp-server/src/arranger/types.ts` tracks this.
    **Standalone:** no; depends on `modules/types` tsup build being in place (already done); coordinate with the Zod-first types work
 
-### `mcp-server` declares Express as a runtime dependency but only uses its types; the MCP SDK serves the app on its own Express 5
+### `mcp-server` types its handlers with Express 4 while the MCP SDK serves them on its own Express 5
 
-**File:** `apps/mcp-server/package.json`; `apps/mcp-server/src/http/app.ts`
-**Severity:** low-medium (two Express majors in one request path, with no compile-time signal)
+**File:** `apps/mcp-server/src/http/app.ts`
+**Severity:** low (one Express major in the request path as of 2026-09-01; the type/runtime skew remains, with no compile-time signal)
 **Kind:** dependency management
-**Issue:** `mcp-server` pins `express: ^4.21.2` while `@modelcontextprotocol/sdk` depends on
-`express: ^5.2.1`, so npm installs both: `node_modules/express` at 4.22.2 and
-`node_modules/@modelcontextprotocol/sdk/node_modules/express` at 5.2.1. `http/app.ts:80` builds the
-serving app with `createMcpExpressApp` from `@modelcontextprotocol/sdk/server/express`, so the object
-handling every request is Express 5, while `http/app.ts:7` types that object and its handlers with
-`Express`, `Request`, and `Response` from Express 4. The mismatch does not surface as a type error
-because the root `overrides` block pins `@types/express` to `4.17.25` tree-wide, so the SDK's own
-`server/express.d.ts` resolves against Express 4 declarations too.
-**Fix:** Remove `express` from `dependencies`: nothing imports it at runtime and the serving app
-comes from the SDK. Keep `@types/express` in `devDependencies`, since `http/app.ts` needs Express
-`Request` and `Response` for `req.body` and `res.status().json()`, and the SDK's own
-`createMcpExpressApp` return type resolves against it.
-**Standalone:** no; the `@types/express` pin is shared with `apps/search-server` and
-`modules/graphql-router`, and the duplicate copy resolves at the MCP SDK v2 migration, where
-`@modelcontextprotocol/express` takes `express` as a peer rather than bundling it
+**Issue:** `http/app.ts:80` builds the serving app with `createMcpExpressApp` from `@modelcontextprotocol/sdk/server/express`, so the object handling every request is the SDK's own Express 5 (`node_modules/@modelcontextprotocol/sdk/node_modules/express` at 5.2.1). `http/app.ts:7` types that object and its handlers with `Express`, `Request`, and `Response` from Express 4. The mismatch does not surface as a type error because the root `overrides` block pins `@types/express` to `4.17.25` tree-wide, so the SDK's own `server/express.d.ts` resolves against Express 4 declarations too.
+
+Partially resolved 2026-09-01: `express` and `cors` are no longer declared by `apps/mcp-server`, so it no longer pulls a second Express 4 copy of its own. `@types/express` stays, since `http/app.ts` needs `Request` and `Response` for `req.body` and `res.status().json()`, and the `createMcpExpressApp` return type resolves against it. What remains is the version skew between those types and the Express 5 runtime.
+**Fix:** Align `@types/express` with the Express 5 runtime, or drop the Express typings in favour of whatever `@modelcontextprotocol/express@2` exposes at the SDK v2 migration, where `express` becomes a peer the consumer declares deliberately.
+**Standalone:** no; the `@types/express` pin is shared with `apps/search-server` and `modules/graphql-router`, so realigning it is gated on those, and the cleanest resolution rides with the MCP SDK v2 migration
 
 ### MCP endpoint has no authentication (URGENT: block demo deployment)
 

--- a/.dev/tech-debt.md
+++ b/.dev/tech-debt.md
@@ -287,14 +287,26 @@ Two consumers need updating in the same pass: `dev:check` (which just calls `tes
    **Fix:** Move introspection types into `modules/types` (the existing shared-types package). Define them as Zod schemas there and infer the TS types: `export const CatalogIntrospectionSchema = zod.object({...}); export type CatalogIntrospection = zod.infer<typeof CatalogIntrospectionSchema>`. Both `search-server` and `mcp-server` import from `@overture-stack/arranger-types`: one schema definition, no raw cross-app file paths, and `mcp-server` can reference the schemas directly as MCP `outputSchema` values. The `TODO` comment in `apps/mcp-server/src/arranger/types.ts` tracks this.
    **Standalone:** no; depends on `modules/types` tsup build being in place (already done); coordinate with the Zod-first types work
 
-### `mcp-server` pins Express 4 and Zod 3; `@modelcontextprotocol/sdk` uses Express 5 and Zod 4 internally
+### `mcp-server` declares Express as a runtime dependency but only uses its types; the MCP SDK serves the app on its own Express 5
 
-**File:** `apps/mcp-server/package.json`
-**Severity:** low-medium (version skew; potential for subtle type or behaviour divergence as the MCP SDK evolves)
+**File:** `apps/mcp-server/package.json`; `apps/mcp-server/src/http/app.ts`
+**Severity:** low-medium (two Express majors in one request path, with no compile-time signal)
 **Kind:** dependency management
-**Issue:** `mcp-server` explicitly pins `express: ^4` and `zod: ^3` for consistency with the rest of the monorepo, but `@modelcontextprotocol/sdk` bundles Express 5 and Zod 4 internally. The two copies coexist for now without breakage, but if the SDK exposes types that depend on its internal Zod 4 schemas at the boundary with our Zod 3 code, assignments can fail at runtime in ways that TypeScript won't catch. The Express gap is lower risk (the SDK's Express is an implementation detail) but should be resolved before the monorepo-wide Express upgrade.
-**Fix:** Coordinate a monorepo-wide upgrade: Express ^4 to ^5 across all packages, then Zod 3 to Zod 4 (Zod 4 has breaking API changes; audit all `.parse()`, `.safeParse()`, and `.refine()` usages). `mcp-server` should be updated in the same pass, not ahead of the rest of the repo.
-**Standalone:** no; requires coordinated upgrade across all workspace packages; do not upgrade `mcp-server` in isolation
+**Issue:** `mcp-server` pins `express: ^4.21.2` while `@modelcontextprotocol/sdk` depends on
+`express: ^5.2.1`, so npm installs both: `node_modules/express` at 4.22.2 and
+`node_modules/@modelcontextprotocol/sdk/node_modules/express` at 5.2.1. `http/app.ts:80` builds the
+serving app with `createMcpExpressApp` from `@modelcontextprotocol/sdk/server/express`, so the object
+handling every request is Express 5, while `http/app.ts:7` types that object and its handlers with
+`Express`, `Request`, and `Response` from Express 4. The mismatch does not surface as a type error
+because the root `overrides` block pins `@types/express` to `4.17.25` tree-wide, so the SDK's own
+`server/express.d.ts` resolves against Express 4 declarations too.
+**Fix:** Remove `express` from `dependencies`: nothing imports it at runtime and the serving app
+comes from the SDK. Keep `@types/express` in `devDependencies`, since `http/app.ts` needs Express
+`Request` and `Response` for `req.body` and `res.status().json()`, and the SDK's own
+`createMcpExpressApp` return type resolves against it.
+**Standalone:** no; the `@types/express` pin is shared with `apps/search-server` and
+`modules/graphql-router`, and the duplicate copy resolves at the MCP SDK v2 migration, where
+`@modelcontextprotocol/express` takes `express` as a peer rather than bundling it
 
 ### MCP endpoint has no authentication (URGENT: block demo deployment)
 

--- a/apps/mcp-server/package.json
+++ b/apps/mcp-server/package.json
@@ -25,9 +25,7 @@
 		"@modelcontextprotocol/sdk": "^1.29.0",
 		"@overture-stack/arranger-types": "file:../../modules/types",
 		"@overture-stack/sqon": "file:../../modules/sqon",
-		"cors": "^2.8.6",
 		"dotenv": "^16.6.1",
-		"express": "^4.21.2",
 		"pino": "^10.3.1",
 		"pino-pretty": "^13.1.3",
 		"tsx": "^4.21.0",
@@ -35,7 +33,6 @@
 	},
 	"devDependencies": {
 		"@tsconfig/node22": "^22.0.5",
-		"@types/cors": "^2.8.12",
 		"@types/express": "^4.17.14",
 		"@types/node": "^25.6.2",
 		"typescript": "^5.8.3"

--- a/apps/search-server/package.json
+++ b/apps/search-server/package.json
@@ -17,6 +17,7 @@
 	"private": true,
 	"scripts": {
 		"dev": "NODE_ENV=development tsx watch --include './src/**/*' --include '../../modules/types/dist/**/*' --include '../../modules/graphql-router/dist/**/*' ./index.ts",
+		"fixtures:introspection-sqon": "tsx ./scripts/generateIntrospectionSqonFixtures.mts",
 		"start": "tsx ./index.ts",
 		"test": "tsx --test"
 	},

--- a/apps/search-server/scripts/README.md
+++ b/apps/search-server/scripts/README.md
@@ -1,0 +1,72 @@
+# `apps/search-server/scripts`
+
+Developer tools, run by hand. Not part of `build`, `start`, or `test`.
+
+## `generateIntrospectionSqonFixtures.mts`
+
+Regenerates the committed fixtures pinning the `GET /introspection/sqon` response.
+
+### Why the fixtures exist
+
+The endpoint is a published contract: REST clients read it, and the MCP Server returns it verbatim
+from `get_sqon_schema`. Nothing in this repository validates data against the JSON Schema it carries,
+and its most important consumer is an LLM reading it to learn how to write a SQON. These fixtures and
+their tests are the only thing that notices when it moves.
+
+### The files
+
+All four sit in [`../src/introspection/`](../src/introspection), beside the endpoint they describe.
+
+| File                                | What it is                                                                     |
+| ----------------------------------- | ------------------------------------------------------------------------------ |
+| `introspectionSqon.schema.json`     | the SQON JSON Schema half of the response                                      |
+| `introspectionSqon.metadata.json`   | the rest: `$schema`, `title`, `description`, `version`, `aliases`, `operators` |
+| `introspectionSqonFixtures.ts`      | filenames, version placeholder, key sorting, fixture reader                    |
+| `introspectionSqonFixtures.test.ts` | the four tests comparing the live response against the fixtures                |
+
+Split in two on purpose: operator metadata and schema shape change for unrelated reasons, so neither
+shows up as noise in the other's diff.
+
+### When to run it
+
+Not speculatively. **The failing test is the signal**: make your change, run
+`npm test -w apps/search-server`, and regenerate if the fixture tests fail.
+
+Expect that when you touch the inputs the response is built from:
+
+- `modules/sqon/src/schema/`, the Zod schemas. New operators, renamed fields, and changed constraints
+  all reach the emitted JSON Schema.
+- `modules/sqon/src/operators/`, which becomes `aliases` and `operators`.
+- `modules/sqon/src/jsonSchema/`, which builds the schema and sets `$id`.
+- [`../src/introspection/sqonDetails.ts`](../src/introspection/sqonDetails.ts), the response envelope.
+- `modules/sqon`'s `zod` or `zod-to-json-schema` versions. A dependency bump can move the output with
+  no code change of ours, which is exactly what these fixtures exist to catch.
+
+A release bumping only `SQON_SCHEMA_VERSION` is not a trigger: the version is placeholdered.
+
+### Usage
+
+```sh
+npm run fixtures:introspection-sqon -w apps/search-server
+```
+
+No server, Elasticsearch, or network needed: `buildSqonDetails()` is a zero-argument pure function.
+
+Then **read the `git diff`** and decide whether `SQON_SCHEMA_VERSION` (which is `modules/sqon`'s own
+package version) needs a bump. Regenerating without reading defeats the point of having these files.
+
+### Three properties the tests depend on
+
+1. **Sorted keys**, so a reordering cannot swamp the diff and hide the real change.
+2. **Version placeholder.** `$id` and `version` embed `SQON_SCHEMA_VERSION`, so the live value would
+   rewrite the fixtures every release. The generator asserts how many occurrences it expects, so a new
+   field carrying the version cannot slip in as a literal.
+3. **Prettier formatting**, because the root `scripts/format-all.sh` sweeps `.json` and would silently
+   reformat a non-canonical fixture, failing the tests for no real reason. `JSON.stringify` alone does
+   not produce that form.
+
+### Naming note
+
+Not `introspectionSqon.envelope.json`: `.gitignore`'s `**/*.env*` dotenv rule also matches
+`*.envelope.json`, which silently excludes the file from commits and from Prettier (which respects
+`.gitignore` by default).

--- a/apps/search-server/scripts/generateIntrospectionSqonFixtures.mts
+++ b/apps/search-server/scripts/generateIntrospectionSqonFixtures.mts
@@ -1,0 +1,77 @@
+#!/usr/bin/env tsx
+/**
+ * Regenerates the committed `GET /introspection/sqon` fixtures.
+ *
+ * Usage: npm run fixtures:introspection-sqon -w apps/search-server
+ *
+ * See ./README.md for when to run this, and for why the fixtures exist at all. Read the resulting
+ * `git diff`: it is a change to a published contract, so decide whether SQON_SCHEMA_VERSION needs a
+ * bump before committing.
+ *
+ * `buildSqonDetails()` is a zero-argument pure function, so no server, Elasticsearch, or network is
+ * involved. Three details the test depends on: the response is split in two so schema and operator
+ * changes stay out of each other's diffs, the version is stored as a placeholder so releases do not
+ * churn the files, and keys are sorted then Prettier-formatted so the diff stays readable and
+ * `scripts/format-all.sh` cannot silently reformat them.
+ */
+import { execFileSync } from 'node:child_process';
+import { writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { SQON_SCHEMA_VERSION } from '@overture-stack/sqon';
+
+import {
+	METADATA_FIXTURE_FILENAME,
+	SCHEMA_FIXTURE_FILENAME,
+	SQON_SCHEMA_VERSION_PLACEHOLDER,
+	sortKeysDeep,
+} from '../src/introspection/introspectionSqonFixtures.js';
+import buildSqonDetails from '../src/introspection/sqonDetails.js';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '../../..');
+const introspectionDir = resolve(dirname(fileURLToPath(import.meta.url)), '../src/introspection');
+
+const { schema, ...metadata } = buildSqonDetails();
+
+/**
+ * Swaps the live version for the placeholder. Asserts the count, so a new field carrying the version
+ * cannot be written as a literal and start churning on release unnoticed.
+ */
+const withPlaceholder = (value: unknown, expectedOccurrences: number, label: string): string => {
+	const serialized = JSON.stringify(sortKeysDeep(value), null, '\t');
+	const occurrences = serialized.split(SQON_SCHEMA_VERSION).length - 1;
+
+	if (occurrences !== expectedOccurrences) {
+		throw new Error(
+			`${label}: expected ${expectedOccurrences} occurrence(s) of the schema version, found ${occurrences}. ` +
+				`Update the expected count here and in introspectionSqonFixtures.ts if this is intentional.`,
+		);
+	}
+
+	return `${serialized.replaceAll(SQON_SCHEMA_VERSION, SQON_SCHEMA_VERSION_PLACEHOLDER)}\n`;
+};
+
+// `schema` carries the version twice, in `version` and in the `$id` URL; the metadata once.
+const written = [
+	[SCHEMA_FIXTURE_FILENAME, withPlaceholder(schema, 2, SCHEMA_FIXTURE_FILENAME)],
+	[METADATA_FIXTURE_FILENAME, withPlaceholder(metadata, 1, METADATA_FIXTURE_FILENAME)],
+] as const;
+
+for (const [filename, contents] of written) {
+	writeFileSync(resolve(introspectionDir, filename), contents);
+}
+
+execFileSync(
+	'npx',
+	[
+		'prettier',
+		'--config',
+		resolve(repoRoot, 'prettier.config.js'),
+		'--write',
+		...written.map(([filename]) => resolve(introspectionDir, filename)),
+	],
+	{ cwd: repoRoot, stdio: 'inherit' },
+);
+
+console.log(`wrote ${written.map(([filename]) => filename).join(', ')} (version ${SQON_SCHEMA_VERSION})`);

--- a/apps/search-server/src/introspection/introspectionSqon.metadata.json
+++ b/apps/search-server/src/introspection/introspectionSqon.metadata.json
@@ -1,0 +1,93 @@
+{
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
+	"aliases": {
+		"!=": "not-in",
+		"!==": "not-in",
+		"<": "lt",
+		"<=": "lte",
+		"=": "in",
+		"==": "in",
+		"===": "in",
+		">": "gt",
+		">=": "gte",
+		"filter": "wildcard"
+	},
+	"description": "JSON Schema and operator metadata for building valid SQON filters.",
+	"operators": {
+		"combination": ["and", "or", "not"],
+		"field": [
+			{
+				"applicableTo": "all",
+				"description": "Field matches any of these values.",
+				"fieldRef": "fieldName",
+				"op": "in",
+				"valueType": "string | number | boolean | Array<string | number | boolean>"
+			},
+			{
+				"applicableTo": "all",
+				"description": "Field does not match any of these values.",
+				"fieldRef": "fieldName",
+				"op": "not-in",
+				"valueType": "string | number | boolean | Array<string | number | boolean>"
+			},
+			{
+				"applicableTo": "all",
+				"description": "At least one nested item is excluded (multi-valued, per-item).",
+				"fieldRef": "fieldName",
+				"op": "some-not-in",
+				"valueType": "string | number | boolean | Array<string | number | boolean>"
+			},
+			{
+				"applicableTo": "all",
+				"description": "Field contains all of these values (multi-valued field only).",
+				"fieldRef": "fieldName",
+				"op": "all",
+				"valueType": "Array<string | number | boolean>"
+			},
+			{
+				"applicableTo": ["long", "integer", "float", "double", "date"],
+				"description": "Field is greater than this value.",
+				"fieldRef": "fieldName",
+				"op": "gt",
+				"valueType": "number | date"
+			},
+			{
+				"applicableTo": ["long", "integer", "float", "double", "date"],
+				"description": "Field is greater than or equal to this value.",
+				"fieldRef": "fieldName",
+				"op": "gte",
+				"valueType": "number | date"
+			},
+			{
+				"applicableTo": ["long", "integer", "float", "double", "date"],
+				"description": "Field is less than this value.",
+				"fieldRef": "fieldName",
+				"op": "lt",
+				"valueType": "number | date"
+			},
+			{
+				"applicableTo": ["long", "integer", "float", "double", "date"],
+				"description": "Field is less than or equal to this value.",
+				"fieldRef": "fieldName",
+				"op": "lte",
+				"valueType": "number | date"
+			},
+			{
+				"applicableTo": ["long", "integer", "float", "double", "date"],
+				"description": "Field is between these two values, both inclusive.",
+				"fieldRef": "fieldName",
+				"op": "between",
+				"valueType": "Array<number | date>"
+			},
+			{
+				"applicableTo": "all",
+				"description": "One or more fields contain this substring pattern.",
+				"fieldRef": "fieldNames",
+				"op": "wildcard",
+				"valueType": "string"
+			}
+		]
+	},
+	"title": "Serialized Query Object Notation",
+	"version": "__SQON_SCHEMA_VERSION__"
+}

--- a/apps/search-server/src/introspection/introspectionSqon.schema.json
+++ b/apps/search-server/src/introspection/introspectionSqon.schema.json
@@ -1,0 +1,229 @@
+{
+	"$defs": {
+		"All": {
+			"additionalProperties": true,
+			"properties": {
+				"content": {
+					"additionalProperties": true,
+					"properties": {
+						"fieldName": {
+							"minLength": 1,
+							"type": "string"
+						},
+						"value": {
+							"items": {
+								"type": ["string", "number", "boolean"]
+							},
+							"minItems": 1,
+							"type": "array"
+						}
+					},
+					"required": ["fieldName", "value"],
+					"type": "object"
+				},
+				"op": {
+					"const": "all",
+					"type": "string"
+				},
+				"pivot": {
+					"type": ["string", "null"]
+				}
+			},
+			"required": ["op", "content"],
+			"type": "object"
+		},
+		"Between": {
+			"additionalProperties": true,
+			"properties": {
+				"content": {
+					"additionalProperties": true,
+					"properties": {
+						"fieldName": {
+							"minLength": 1,
+							"type": "string"
+						},
+						"value": {
+							"items": {
+								"$ref": "#/$defs/All/properties/content/properties/value/items"
+							},
+							"maxItems": 2,
+							"minItems": 2,
+							"type": "array"
+						}
+					},
+					"required": ["fieldName", "value"],
+					"type": "object"
+				},
+				"op": {
+					"const": "between",
+					"type": "string"
+				},
+				"pivot": {
+					"type": ["string", "null"]
+				}
+			},
+			"required": ["op", "content"],
+			"type": "object"
+		},
+		"Group": {
+			"additionalProperties": true,
+			"properties": {
+				"content": {
+					"items": {
+						"oneOf": [
+							{
+								"$ref": "#/$defs/Group"
+							},
+							{
+								"$ref": "#/$defs/Leaf"
+							}
+						]
+					},
+					"type": "array"
+				},
+				"op": {
+					"enum": ["and", "or", "not"],
+					"type": "string"
+				},
+				"pivot": {
+					"type": ["string", "null"]
+				}
+			},
+			"required": ["op", "content"],
+			"type": "object"
+		},
+		"InLike": {
+			"additionalProperties": true,
+			"properties": {
+				"content": {
+					"additionalProperties": true,
+					"properties": {
+						"fieldName": {
+							"minLength": 1,
+							"type": "string"
+						},
+						"value": {
+							"oneOf": [
+								{
+									"$ref": "#/$defs/All/properties/content/properties/value/items"
+								},
+								{
+									"items": {
+										"$ref": "#/$defs/All/properties/content/properties/value/items"
+									},
+									"type": "array"
+								}
+							]
+						}
+					},
+					"required": ["fieldName", "value"],
+					"type": "object"
+				},
+				"op": {
+					"enum": ["in", "not-in", "some-not-in", "=", "==", "===", "!=", "!=="],
+					"type": "string"
+				},
+				"pivot": {
+					"type": ["string", "null"]
+				}
+			},
+			"required": ["op", "content"],
+			"type": "object"
+		},
+		"Leaf": {
+			"oneOf": [
+				{
+					"$ref": "#/$defs/InLike"
+				},
+				{
+					"$ref": "#/$defs/All"
+				},
+				{
+					"$ref": "#/$defs/RangeLike"
+				},
+				{
+					"$ref": "#/$defs/Between"
+				},
+				{
+					"$ref": "#/$defs/Wildcard"
+				}
+			]
+		},
+		"RangeLike": {
+			"additionalProperties": true,
+			"properties": {
+				"content": {
+					"additionalProperties": true,
+					"properties": {
+						"fieldName": {
+							"minLength": 1,
+							"type": "string"
+						},
+						"value": {
+							"$ref": "#/$defs/InLike/properties/content/properties/value"
+						}
+					},
+					"required": ["fieldName", "value"],
+					"type": "object"
+				},
+				"op": {
+					"enum": ["gt", "gte", "lt", "lte", ">", ">=", "<", "<="],
+					"type": "string"
+				},
+				"pivot": {
+					"type": ["string", "null"]
+				}
+			},
+			"required": ["op", "content"],
+			"type": "object"
+		},
+		"SQON": {
+			"oneOf": [
+				{
+					"$ref": "#/$defs/Group"
+				},
+				{
+					"$ref": "#/$defs/Leaf"
+				}
+			]
+		},
+		"Wildcard": {
+			"additionalProperties": true,
+			"properties": {
+				"content": {
+					"additionalProperties": true,
+					"properties": {
+						"fieldNames": {
+							"items": {
+								"minLength": 1,
+								"type": "string"
+							},
+							"minItems": 1,
+							"type": "array"
+						},
+						"value": {
+							"type": "string"
+						}
+					},
+					"required": ["fieldNames", "value"],
+					"type": "object"
+				},
+				"op": {
+					"enum": ["wildcard", "filter"],
+					"type": "string"
+				},
+				"pivot": {
+					"type": ["string", "null"]
+				}
+			},
+			"required": ["op", "content"],
+			"type": "object"
+		}
+	},
+	"$id": "https://overture-stack.org/schemas/arranger/sqon/v__SQON_SCHEMA_VERSION__.schema.json",
+	"$ref": "#/$defs/SQON",
+	"$schema": "https://json-schema.org/draft/2020-12/schema",
+	"description": "JSON Schema for Serialized Query Object Notation.",
+	"title": "Serialized Query Object Notation",
+	"version": "__SQON_SCHEMA_VERSION__"
+}

--- a/apps/search-server/src/introspection/introspectionSqonFixtures.test.ts
+++ b/apps/search-server/src/introspection/introspectionSqonFixtures.test.ts
@@ -1,0 +1,104 @@
+import assert from 'node:assert/strict';
+import { suite, test } from 'node:test';
+
+import express from 'express';
+import request from 'supertest';
+
+import {
+	METADATA_FIXTURE_FILENAME,
+	readFixture,
+	regenerationHint,
+	SCHEMA_FIXTURE_FILENAME,
+	sortKeysDeep,
+} from '#introspection/introspectionSqonFixtures.js';
+import buildSqonDetails from '#introspection/sqonDetails.js';
+
+import createIntrospectionRoutes from './index.js';
+
+/**
+ * `GET /introspection/sqon` is a published contract: REST clients read it, and the MCP Server returns
+ * it verbatim from `get_sqon_schema`. Nothing else in this repo validates the JSON Schema it carries,
+ * so these fixtures are the only thing that notices when it moves.
+ *
+ * A failure here is not a broken test, it is the contract telling you it changed. See
+ * ../../scripts/README.md.
+ */
+suite('GET /introspection/sqon: published contract', () => {
+	const { schema, ...metadata } = buildSqonDetails();
+
+	test('the JSON Schema matches its committed fixture', () => {
+		assert.deepEqual(sortKeysDeep(schema), readFixture(SCHEMA_FIXTURE_FILENAME), regenerationHint);
+	});
+
+	test('the operator metadata matches its committed fixture', () => {
+		assert.deepEqual(sortKeysDeep(metadata), readFixture(METADATA_FIXTURE_FILENAME), regenerationHint);
+	});
+
+	// The fixtures are built from buildSqonDetails() directly; this proves they describe the
+	// endpoint, not just the function behind it.
+	test('the served response is exactly the two fixtures combined', async () => {
+		const router = createIntrospectionRoutes({
+			catalogs: { donor: { documentType: 'donor' } },
+			catalogueRouters: {},
+			catalogueStatuses: { donor: { status: 'available' } },
+		});
+
+		const response = await request(express().use(router)).get('/introspection/sqon');
+
+		assert.equal(response.status, 200);
+		assert.deepEqual(sortKeysDeep(response.body), {
+			...(readFixture(METADATA_FIXTURE_FILENAME) as Record<string, unknown>),
+			schema: readFixture(SCHEMA_FIXTURE_FILENAME),
+		});
+	});
+
+	/**
+	 * Guards the latent `$ref` defect in `.dev/tech-debt.md`: `normalizeUnionKeywords` rewrites
+	 * `anyOf` to `oneOf` without touching `$ref` path strings, so any pointer routed through an
+	 * `anyOf` segment stops resolving. None currently is, but only because of `$defs` declaration
+	 * order. The Zod 4 rewrite must preserve this.
+	 */
+	test('every $ref in the published schema resolves', () => {
+		const document = readFixture(SCHEMA_FIXTURE_FILENAME);
+		const refs = new Set<string>();
+
+		const collectRefs = (value: unknown): void => {
+			if (Array.isArray(value)) {
+				return value.forEach(collectRefs);
+			}
+
+			if (!value || typeof value !== 'object') {
+				return;
+			}
+
+			for (const [key, childValue] of Object.entries(value)) {
+				if (key === '$ref' && typeof childValue === 'string') {
+					refs.add(childValue);
+				} else {
+					collectRefs(childValue);
+				}
+			}
+		};
+
+		collectRefs(document);
+		assert.ok(refs.size > 0, 'expected the published schema to contain at least one $ref');
+
+		for (const ref of refs) {
+			assert.ok(ref.startsWith('#/'), `only local JSON Pointers are expected, found ${ref}`);
+
+			// Walked segment by segment so a failure names the offending ref.
+			const resolved = ref
+				.slice(2)
+				.split('/')
+				.reduce<unknown>((node, segment) => {
+					if (!node || typeof node !== 'object' || !(segment in node)) {
+						return undefined;
+					}
+
+					return (node as Record<string, unknown>)[segment];
+				}, document);
+
+			assert.notEqual(resolved, undefined, `dangling $ref: "${ref}" does not resolve`);
+		}
+	});
+});

--- a/apps/search-server/src/introspection/introspectionSqonFixtures.ts
+++ b/apps/search-server/src/introspection/introspectionSqonFixtures.ts
@@ -1,0 +1,61 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { SQON_SCHEMA_VERSION } from '@overture-stack/sqon';
+
+/**
+ * Shared by the `GET /introspection/sqon` fixtures, their test, and the generator that writes them
+ * (`scripts/generateIntrospectionSqonFixtures.mts`), so the two sides cannot drift.
+ */
+
+export const SCHEMA_FIXTURE_FILENAME = 'introspectionSqon.schema.json';
+
+/**
+ * The response minus the JSON Schema: `$schema`, `title`, `description`, `version`, `aliases`,
+ * `operators`.
+ *
+ * Not "envelope": `.gitignore`'s `**\/*.env*` dotenv rule also matches `*.envelope.json`, silently
+ * excluding the file from both commits and Prettier.
+ */
+export const METADATA_FIXTURE_FILENAME = 'introspectionSqon.metadata.json';
+
+/** Stands in for SQON_SCHEMA_VERSION, so a release bump does not rewrite the fixtures. */
+export const SQON_SCHEMA_VERSION_PLACEHOLDER = '__SQON_SCHEMA_VERSION__';
+
+/** Sorts object keys recursively, so Zod 4's different key order cannot swamp the migration diff. */
+export const sortKeysDeep = (value: unknown): unknown => {
+	if (Array.isArray(value)) {
+		return value.map(sortKeysDeep);
+	}
+
+	if (!value || typeof value !== 'object') {
+		return value;
+	}
+
+	return Object.fromEntries(
+		Object.keys(value as Record<string, unknown>)
+			.sort()
+			.map((key) => [key, sortKeysDeep((value as Record<string, unknown>)[key])]),
+	);
+};
+
+/**
+ * Reads a fixture, substituting the live schema version back in.
+ *
+ * `readFileSync` rather than a JSON import: imported JSON is one cached object shared by every
+ * importer, and the substitution below mutates.
+ */
+export const readFixture = (filename: string): unknown => {
+	const fixturePath = resolve(dirname(fileURLToPath(import.meta.url)), filename);
+	const contents = readFileSync(fixturePath, 'utf8');
+
+	return JSON.parse(contents.replaceAll(SQON_SCHEMA_VERSION_PLACEHOLDER, SQON_SCHEMA_VERSION));
+};
+
+/** Appended to every mismatch: the contract moved, so the fix is never "make the test pass". */
+export const regenerationHint = [
+	'The published GET /introspection/sqon contract has changed.',
+	'Regenerate with: npm run fixtures:introspection-sqon -w apps/search-server',
+	'Then review the git diff and decide whether SQON_SCHEMA_VERSION needs a bump before committing.',
+].join('\n');

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,9 +51,7 @@
 				"@modelcontextprotocol/sdk": "^1.29.0",
 				"@overture-stack/arranger-types": "file:../../modules/types",
 				"@overture-stack/sqon": "file:../../modules/sqon",
-				"cors": "^2.8.6",
 				"dotenv": "^16.6.1",
-				"express": "^4.21.2",
 				"pino": "^10.3.1",
 				"pino-pretty": "^13.1.3",
 				"tsx": "^4.21.0",
@@ -61,7 +59,6 @@
 			},
 			"devDependencies": {
 				"@tsconfig/node22": "^22.0.5",
-				"@types/cors": "^2.8.12",
 				"@types/express": "^4.17.14",
 				"@types/node": "^25.6.2",
 				"typescript": "^5.8.3"


### PR DESCRIPTION
## Summary

**PR 1 of 3** for the Zod 4 migration.
- PR 2: #1097 
- PR 3: #1098 

Pins the `GET /introspection/sqon` response with fixtures and tests so the Zod 4 migration in [PR 2](https://github.com/overture-stack/arranger/pull/1097) has something to diff against, and drops three dependencies `apps/mcp-server` never used. No behaviour changes.

**No breaking changes.** This PR is additive plus a dependency removal, and is safe to merge on its own even if PRs 2 and 3 stall.

## Issues
- N/A

## Description of Changes

### Search Server

* Added two fixtures and four tests covering the `GET /introspection/sqon` response so that changes to the published contract are caught and handled deliberately
  * The endpoint is read directly by REST clients and returned verbatim by the MCP Server's `get_sqon_schema` tool, but nothing validated its shape previously
  * Split across `introspectionSqon.schema.json` and `introspectionSqon.metadata.json` so that schema changes and operator-metadata changes stay out of each other's diffs; PR 2 causes changes to schema only
  * The version is stored as a placeholder and keys are sorted, so neither a release nor a key reordering churns the files
* Added `generateIntrospectionSqonFixtures.mts` and a `fixtures:introspection-sqon` npm script to regenerate them, with a `scripts/README.md` covering when to run it and why the fixtures exist
  * `buildSqonDetails()` is a zero-argument pure function, so regenerating needs no server, Elasticsearch, or network

### MCP Server

* Removed unused `express`, `cors`, and `@types/cors` from `dependencies` so that the manifest reflects what the app actually uses
  * Nothing imports either at runtime: the only reference is a type-only `express` import in `src/http/app.ts`, and the serving app is built by the SDK's own bundled Express 5
  * Both stay resolvable through `apps/search-server` and `modules/graphql-router`, and `@types/express` stays declared because `src/http/app.ts` needs `Request` and `Response`

### Docs

* Corrected the tech-debt entry on dangling `$ref` pointers to describe a latent defect rather than a live one
  * Every pointer in the published schema currently resolves, and only because of `$defs` declaration order; reordering the map is enough to break one
* Reframed the Express entry around the type/runtime skew that remains, now that the duplicate Express 4 copy is gone

### Special Instructions
Before running these changes locally, you should re-install dependencies and rebuild the SQON module:
```sh
npm ci                 # dependency removals changed package-lock.json
npm run modules:build
```

## Readiness Checklist

- [x] **Self Review**
  - I have performed a self review of code
  - I have run the application locally and manually tested the feature
  - I have checked all updates to correct typos and misspellings
- [x] **Formatting**
  - Code follows the project style guide
  - Automated code formatters (ie. Prettier) have been run
- [x] **Local Testing**
  - Successfully built all packages locally
  - Successfully ran all test suites, all unit and integration tests pass
- [x] **Updated Tests**
  - Unit and integration tests have been added that describe the bug that was fixed or the features that were added
- [x] **Documentation**
  - All new environment variables added to `.env.schema` file and documented in the README
  - All changes to server HTTP endpoints have open-api documentation
  - All new functions exported from their module have TSDoc comment documentation
